### PR TITLE
feat: add MasonryGrid and MasonryChild components

### DIFF
--- a/packages/core/src/components/MasonryChild.tsx
+++ b/packages/core/src/components/MasonryChild.tsx
@@ -1,101 +1,106 @@
 "use client";
 
-import React, {forwardRef, useEffect} from "react";
+import React, { forwardRef, useEffect } from "react";
 
 import { Flex } from ".";
 import { SpacingToken } from "@/types";
 
-interface MasonryChildProps extends React.ComponentProps<typeof Flex>{
-    additionalHeight?: number;
+interface MasonryChildProps extends React.ComponentProps<typeof Flex> {
+  additionalHeight?: number;
 }
 
 const MasonryChild = forwardRef<HTMLDivElement, MasonryChildProps>(
-    ({ width, height, additionalHeight = 0, className, style, ...rest }, ref) => {
-        const [parsed, setParsed] = React.useState<{ width?: number, height?: number }>({});
+  ({ width, height, additionalHeight = 0, className, style, ...rest }, ref) => {
+    const [parsed, setParsed] = React.useState<{ width?: number; height?: number }>({});
 
-        const parseDimension = (
-            value: number | SpacingToken | undefined,
-            type: "width" | "height",
-        ): string | undefined => {
-            if (value === undefined) return undefined;
-            if (typeof value === "number") return `${value}rem`;
-            if (
-                [
-                    "0",
-                    "1",
-                    "2",
-                    "4",
-                    "8",
-                    "12",
-                    "16",
-                    "20",
-                    "24",
-                    "32",
-                    "40",
-                    "48",
-                    "56",
-                    "64",
-                    "80",
-                    "104",
-                    "128",
-                    "160",
-                ].includes(value)
-            ) {
-                return `var(--static-space-${value})`;
-            }
-            if (["xs", "s", "m", "l", "xl"].includes(value)) {
-                return `var(--responsive-${type}-${value})`;
-            }
-            return undefined;
-        };
+    const parseDimension = (
+      value: number | SpacingToken | undefined,
+      type: "width" | "height",
+    ): string | undefined => {
+      if (value === undefined) return undefined;
+      if (typeof value === "number") return `${value}rem`;
+      if (
+        [
+          "0",
+          "1",
+          "2",
+          "4",
+          "8",
+          "12",
+          "16",
+          "20",
+          "24",
+          "32",
+          "40",
+          "48",
+          "56",
+          "64",
+          "80",
+          "104",
+          "128",
+          "160",
+        ].includes(value)
+      ) {
+        return `var(--static-space-${value})`;
+      }
+      if (["xs", "s", "m", "l", "xl"].includes(value)) {
+        return `var(--responsive-${type}-${value})`;
+      }
+      return undefined;
+    };
 
-        const resolveToPx = (value: string | undefined, context: HTMLElement = document.body): number | undefined => {
-            if (!value) return undefined;
-            const el = document.createElement('div');
-            el.style.position = 'absolute';
-            el.style.visibility = 'hidden';
-            el.style.height = value;
-            context.appendChild(el);
+    const resolveToPx = (
+      value: string | undefined,
+      context: HTMLElement = document.body,
+    ): number | undefined => {
+      if (!value) return undefined;
+      const el = document.createElement("div");
+      el.style.position = "absolute";
+      el.style.visibility = "hidden";
+      el.style.height = value;
+      context.appendChild(el);
 
-            const computed = getComputedStyle(el).height;
-            context.removeChild(el);
+      const computed = getComputedStyle(el).height;
+      context.removeChild(el);
 
-            const px = parseFloat(computed);
-            return isNaN(px) ? undefined : px;
+      const px = parseFloat(computed);
+      return isNaN(px) ? undefined : px;
+    };
+
+    useEffect(() => {
+      const widthPx = resolveToPx(parseDimension(width, "width"), document.body);
+      const heightPx = resolveToPx(parseDimension(height, "height"), document.body);
+
+      setParsed({
+        width: widthPx,
+        height: heightPx,
+      });
+    }, [width, height]);
+
+    return (
+      <Flex
+        ref={ref}
+        className={`masonry-child ${className ?? ""}`}
+        style={
+          {
+            ...style,
+            gridRow:
+              parsed.height && parsed.width
+                ? `span ${Math.ceil(Math.ceil((parsed.width * parsed.height) / parsed.width) / 10) + additionalHeight}`
+                : undefined,
+            justifySelf: "center",
+            margin: 0,
+            width: parsed.width ? `${parsed.width}px` : undefined,
+            height: parsed.height ? `${parsed.height}px` : undefined,
+          } as React.CSSProperties
         }
-
-        useEffect(() => {
-            const widthPx = resolveToPx(parseDimension(width, 'width'), document.body);
-            const heightPx = resolveToPx(parseDimension(height, 'height'), document.body);
-
-            setParsed({
-                width: widthPx,
-                height: heightPx,
-            });
-        }, [width, height]);
-
-        return (
-            <Flex
-                ref={ref}
-                className={`masonry-child ${className ?? ""}`}
-                style={{
-                    ...style,
-                    gridRow:
-                        (parsed.height && parsed.width)
-                            ? `span ${Math.ceil(Math.ceil(parsed.width * (parsed.height) / parsed.width) / 10) + additionalHeight}`
-                            : undefined,
-                    justifySelf: "center",
-                    margin: 0,
-                    width: parsed.width ? `${parsed.width}px` : undefined,
-                    height: parsed.height ? `${parsed.height}px` : undefined,
-                } as React.CSSProperties}
-                fit
-                {...rest}
-            >
-                {/* children go here */}
-            </Flex>
-        );
-    }
+        fit
+        {...rest}
+      >
+        {/* children go here */}
+      </Flex>
+    );
+  },
 );
 
 MasonryChild.displayName = "MasonryChild";

--- a/packages/core/src/components/MasonryChild.tsx
+++ b/packages/core/src/components/MasonryChild.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import React, {forwardRef, useEffect} from "react";
+
+import { Flex } from ".";
+import { SpacingToken } from "@/types";
+
+interface MasonryChildProps extends React.ComponentProps<typeof Flex>{
+    additionalHeight?: number;
+}
+
+const MasonryChild = forwardRef<HTMLDivElement, MasonryChildProps>(
+    ({ width, height, additionalHeight = 0, className, style, ...rest }, ref) => {
+        const [parsed, setParsed] = React.useState<{ width?: number, height?: number }>({});
+
+        const parseDimension = (
+            value: number | SpacingToken | undefined,
+            type: "width" | "height",
+        ): string | undefined => {
+            if (value === undefined) return undefined;
+            if (typeof value === "number") return `${value}rem`;
+            if (
+                [
+                    "0",
+                    "1",
+                    "2",
+                    "4",
+                    "8",
+                    "12",
+                    "16",
+                    "20",
+                    "24",
+                    "32",
+                    "40",
+                    "48",
+                    "56",
+                    "64",
+                    "80",
+                    "104",
+                    "128",
+                    "160",
+                ].includes(value)
+            ) {
+                return `var(--static-space-${value})`;
+            }
+            if (["xs", "s", "m", "l", "xl"].includes(value)) {
+                return `var(--responsive-${type}-${value})`;
+            }
+            return undefined;
+        };
+
+        const resolveToPx = (value: string | undefined, context: HTMLElement = document.body): number | undefined => {
+            if (!value) return undefined;
+            const el = document.createElement('div');
+            el.style.position = 'absolute';
+            el.style.visibility = 'hidden';
+            el.style.height = value;
+            context.appendChild(el);
+
+            const computed = getComputedStyle(el).height;
+            context.removeChild(el);
+
+            const px = parseFloat(computed);
+            return isNaN(px) ? undefined : px;
+        }
+
+        useEffect(() => {
+            const widthPx = resolveToPx(parseDimension(width, 'width'), document.body);
+            const heightPx = resolveToPx(parseDimension(height, 'height'), document.body);
+
+            setParsed({
+                width: widthPx,
+                height: heightPx,
+            });
+        }, [width, height]);
+
+        return (
+            <Flex
+                ref={ref}
+                className={`masonry-child ${className ?? ""}`}
+                style={{
+                    ...style,
+                    gridRow:
+                        (parsed.height && parsed.width)
+                            ? `span ${Math.ceil(Math.ceil(parsed.width * (parsed.height) / parsed.width) / 10) + additionalHeight}`
+                            : undefined,
+                    justifySelf: "center",
+                    margin: 0,
+                    width: parsed.width ? `${parsed.width}px` : undefined,
+                    height: parsed.height ? `${parsed.height}px` : undefined,
+                } as React.CSSProperties}
+                fit
+                {...rest}
+            >
+                {/* children go here */}
+            </Flex>
+        );
+    }
+);
+
+MasonryChild.displayName = "MasonryChild";
+
+export default MasonryChild;

--- a/packages/core/src/components/MasonryGrid.module.scss
+++ b/packages/core/src/components/MasonryGrid.module.scss
@@ -1,0 +1,7 @@
+.grid {
+  display: grid;
+  justify-content: center;
+  width: 100%;
+  margin-block: calc(1rem / 3);
+  padding-inline: calc(1rem * 1);
+}

--- a/packages/core/src/components/MasonryGrid.tsx
+++ b/packages/core/src/components/MasonryGrid.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { forwardRef } from "react";
+
+import { Flex } from ".";
+import styles from "./MasonryGrid.module.scss";
+import {SpacingToken} from "@/types";
+
+interface MasonryGridProps extends React.ComponentProps<typeof Flex>{
+    rowWidth?: number | SpacingToken;
+    autoRows?: string;
+}
+
+const MasonryGrid = forwardRef<HTMLDivElement, MasonryGridProps>(
+    ({ rowWidth, autoRows, className, style, ...rest }, ref) => {
+
+        const parseDimension = (
+            value: number | SpacingToken | undefined,
+            type: "width" | "height",
+        ): string | undefined => {
+            if (value === undefined) return undefined;
+            if (typeof value === "number") return `${value}rem`;
+            if (
+                [
+                    "0",
+                    "1",
+                    "2",
+                    "4",
+                    "8",
+                    "12",
+                    "16",
+                    "20",
+                    "24",
+                    "32",
+                    "40",
+                    "48",
+                    "56",
+                    "64",
+                    "80",
+                    "104",
+                    "128",
+                    "160",
+                ].includes(value)
+            ) {
+                return `var(--static-space-${value})`;
+            }
+            if (["xs", "s", "m", "l", "xl"].includes(value)) {
+                return `var(--responsive-${type}-${value})`;
+            }
+            return undefined;
+        };
+
+        const parsed = {
+            rowWidth: parseDimension(rowWidth, "width"),
+        }
+
+        return (
+            <Flex
+                ref={ref}
+                className={`${styles.grid} ${className}`}
+                style={{
+                    ...style,
+                    gridTemplateColumns: `repeat(auto-fit, minmax(${ parsed.rowWidth ? parsed.rowWidth : `160px`}, 1fr))`,
+                    gridAutoRows: autoRows ? autoRows : `10px`
+                }}
+                {...rest}
+            >
+                {/* children go here */}
+            </Flex>
+        );
+    }
+);
+
+MasonryGrid.displayName = "MasonryGrid";
+
+export default MasonryGrid;

--- a/packages/core/src/components/MasonryGrid.tsx
+++ b/packages/core/src/components/MasonryGrid.tsx
@@ -4,71 +4,70 @@ import { forwardRef } from "react";
 
 import { Flex } from ".";
 import styles from "./MasonryGrid.module.scss";
-import {SpacingToken} from "@/types";
+import { SpacingToken } from "@/types";
 
-interface MasonryGridProps extends React.ComponentProps<typeof Flex>{
-    rowWidth?: number | SpacingToken;
-    autoRows?: string;
+interface MasonryGridProps extends React.ComponentProps<typeof Flex> {
+  rowWidth?: number | SpacingToken;
+  autoRows?: string;
 }
 
 const MasonryGrid = forwardRef<HTMLDivElement, MasonryGridProps>(
-    ({ rowWidth, autoRows, className, style, ...rest }, ref) => {
+  ({ rowWidth, autoRows, className, style, ...rest }, ref) => {
+    const parseDimension = (
+      value: number | SpacingToken | undefined,
+      type: "width" | "height",
+    ): string | undefined => {
+      if (value === undefined) return undefined;
+      if (typeof value === "number") return `${value}rem`;
+      if (
+        [
+          "0",
+          "1",
+          "2",
+          "4",
+          "8",
+          "12",
+          "16",
+          "20",
+          "24",
+          "32",
+          "40",
+          "48",
+          "56",
+          "64",
+          "80",
+          "104",
+          "128",
+          "160",
+        ].includes(value)
+      ) {
+        return `var(--static-space-${value})`;
+      }
+      if (["xs", "s", "m", "l", "xl"].includes(value)) {
+        return `var(--responsive-${type}-${value})`;
+      }
+      return undefined;
+    };
 
-        const parseDimension = (
-            value: number | SpacingToken | undefined,
-            type: "width" | "height",
-        ): string | undefined => {
-            if (value === undefined) return undefined;
-            if (typeof value === "number") return `${value}rem`;
-            if (
-                [
-                    "0",
-                    "1",
-                    "2",
-                    "4",
-                    "8",
-                    "12",
-                    "16",
-                    "20",
-                    "24",
-                    "32",
-                    "40",
-                    "48",
-                    "56",
-                    "64",
-                    "80",
-                    "104",
-                    "128",
-                    "160",
-                ].includes(value)
-            ) {
-                return `var(--static-space-${value})`;
-            }
-            if (["xs", "s", "m", "l", "xl"].includes(value)) {
-                return `var(--responsive-${type}-${value})`;
-            }
-            return undefined;
-        };
+    const parsed = {
+      rowWidth: parseDimension(rowWidth, "width"),
+    };
 
-        const parsed = {
-            rowWidth: parseDimension(rowWidth, "width"),
-        }
-
-        return (
-            <Flex
-                ref={ref}
-                className={`${styles.grid} ${className}`}
-                style={{
-                    ...style,
-                    gridTemplateColumns: `repeat(auto-fit, minmax(${ parsed.rowWidth ? parsed.rowWidth : `160px`}, 1fr))`,
-                    gridAutoRows: autoRows ? autoRows : `10px`
-                }}
-                {...rest}
-            >
-                {/* children go here */}
-            </Flex>
-        );
-    }
+    return (
+      <Flex
+        ref={ref}
+        className={`${styles.grid} ${className}`}
+        style={{
+          ...style,
+          gridTemplateColumns: `repeat(auto-fit, minmax(${parsed.rowWidth ? parsed.rowWidth : `160px`}, 1fr))`,
+          gridAutoRows: autoRows ? autoRows : `10px`,
+        }}
+        {...rest}
+      >
+        {/* children go here */}
+      </Flex>
+    );
+  },
 );
 
 MasonryGrid.displayName = "MasonryGrid";

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -81,3 +81,5 @@ export * from "./Tooltip";
 export * from "./ThemeSwitcher";
 export * from "./User";
 export * from "./UserMenu";
+export * from "./MasonryGrid";
+export * from "./MasonryChild";


### PR DESCRIPTION
Components for creating a masonry-like grid.

**Probable usage scenarios:**
- Creating a gallery of images of different heights.

**Components:**
- MasonryGrid — Used as the base of the grid.
- MasonryChild — Wrapping component.

**Unique parameters:**
- MasonryGrid 
  - rowWidth - `number | SpacingToken`
  - autoRows - `string`
- MasonryChild 
  - additionalHeight - `number`

**Example of usage:**
```tsx
          <MasonryGrid
              autoRows={'10px'}
              rowWidth={'160'}
              fill
          >
              {...[16, 12, 4, 6, 16, 12, 8, 24, 4, 12, 6, 2].map((height, index) => (
                <MasonryChild
                    key={index}
                    width={'160'}
                    height={height}
                    additionalHeight={2}
                >
                    <Flex
                        key={index}
                        background="overlay"
                        radius="l"
                        border="neutral-alpha-medium"
                        fill
                    />
                </MasonryChild>
                ))}
          </MasonryGrid>
```

![Example](https://github.com/user-attachments/assets/d2822105-3bc7-419f-9023-de1edc19c83b)
