### PR TITLE
feat: add MasonryGrid component for flexible column layouts

### DIFF
--- a/packages/core/src/components/MasonryGrid.tsx
+++ b/packages/core/src/components/MasonryGrid.tsx
@@ -1,0 +1,79 @@
+import React, { forwardRef } from "react";
+import type { CSSProperties, ReactNode } from "react";
+import { Flex } from "./Flex";
+import { SpacingToken } from "../types";
+
+// Utility to parse token to CSS value
+function parseToken(value: SpacingToken | "-1" | number | undefined, type: "width" | "height") {
+    if (value === undefined) return undefined;
+    if (typeof value === "number") return `${value}rem`;
+    if (
+        [
+            "0",
+            "1",
+            "2",
+            "4",
+            "8",
+            "12",
+            "16",
+            "20",
+            "24",
+            "32",
+            "40",
+            "48",
+            "56",
+            "64",
+            "80",
+            "104",
+            "128",
+            "160",
+        ].includes(value)
+    ) {
+        return `var(--static-space-${value})`;
+    }
+    if (["xs", "s", "m", "l", "xl"].includes(value)) {
+        return `var(--responsive-${type}-${value})`;
+    }
+    return undefined;
+}
+
+export interface MasonryGridProps extends React.ComponentProps<typeof Flex> {
+    children: ReactNode;
+    columnWidth?: SpacingToken | number | undefined;
+    gap?: SpacingToken | "-1" | undefined;
+    style?: CSSProperties;
+    className?: string;
+}
+
+export const MasonryGrid = forwardRef<HTMLDivElement, MasonryGridProps>(
+    ({ children, columnWidth = "24", gap = "8", style, className, ...rest }, ref) => {
+        // Masonry effect using CSS columns
+        const columnWidthValue = parseToken(columnWidth, "width") ?? "160px";
+        const gapValue = parseToken(gap, "width") ?? "16px";
+        const masonryStyle: CSSProperties = {
+            display: "block", // force block for columns layout
+            columnWidth: columnWidthValue,
+            columnGap: gapValue,
+            ...style,
+        };
+        return (
+            <Flex ref={ref} style={masonryStyle} className={className} {...rest}>
+                {/* Each child should be block-level for proper masonry effect */}
+                {React.Children.map(children, (child) => (
+                    <div
+                        style={{
+                            breakInside: "avoid",
+                            marginBottom: gapValue,
+                            width: columnWidthValue,
+                            height: "fit-content",
+                            minWidth: columnWidthValue,
+                        }}
+                    >
+                        {child}
+                    </div>
+                ))}
+            </Flex>
+        );
+    },
+);
+MasonryGrid.displayName = "MasonryGrid";

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -94,3 +94,4 @@ export * from "./Tooltip";
 export * from "./ThemeSwitcher";
 export * from "./User";
 export * from "./UserMenu";
+export * from "./MasonryGrid";


### PR DESCRIPTION
A better version of a [past component](https://github.com/once-ui-system/core/pull/1).

Usage:
```tsx
          <MasonryGrid
              columnWidth="160"
              gap="16"
              fill
          >
              {...[16, 12, 4, 6, 16, 12, 8, 24, 4, 12, 6, 2].map((height, index) => (
                  <Flex
                      key={index}
                      background="overlay"
                      radius="l"
                      border="neutral-alpha-medium"
                      fill
                      height={height}
                  />
              ))}
          </MasonryGrid>
```

<img width="779" height="618" alt="image" src="https://github.com/user-attachments/assets/acafc0f7-7ee0-42c7-9d0d-eec122a0b715" />
