### PR TITLE
fix: update breakpoint management to use CSS custom properties

### DIFF
--- a/packages/core/src/contexts/LayoutProvider.tsx
+++ b/packages/core/src/contexts/LayoutProvider.tsx
@@ -68,23 +68,31 @@ const LayoutProvider: React.FC<LayoutProviderProps> = ({
   };
 
   useEffect(() => {
-    // Initialize width
-    const updateWidth = () => {
-      const newWidth = window.innerWidth;
-      setWidth(newWidth);
-      setCurrentBreakpoint(getCurrentBreakpoint(newWidth));
-    };
+      // Update CSS custom properties
+      const root = document.documentElement;
+      Object.entries(breakpoints).forEach(([key, value]) => {
+          if (value !== Infinity) {
+              root.style.setProperty(`--breakpoint-${key}`, `${value}px`);
+          }
+      });
 
-    // Set initial width
-    updateWidth();
+        // Initialize width
+        const updateWidth = () => {
+            const newWidth = window.innerWidth;
+            setWidth(newWidth);
+            setCurrentBreakpoint(getCurrentBreakpoint(newWidth));
+        };
 
-    // Add resize listener
-    window.addEventListener('resize', updateWidth);
+        // Set initial width
+        updateWidth();
 
-    return () => {
-      window.removeEventListener('resize', updateWidth);
-    };
-  }, [breakpoints]);
+        // Add resize listener
+        window.addEventListener('resize', updateWidth);
+
+        return () => {
+            window.removeEventListener('resize', updateWidth);
+        };
+    }, [breakpoints]);
 
   const value: LayoutContextType = {
     currentBreakpoint,

--- a/packages/core/src/styles/breakpoints.scss
+++ b/packages/core/src/styles/breakpoints.scss
@@ -1,6 +1,12 @@
-$breakpoint-s: 768px;
-$breakpoint-m: 1024px;
-$breakpoint-l: 1440px;
+:root {
+  --breakpoint-s: 768px;
+  --breakpoint-m: 1024px;
+  --breakpoint-l: 1440px;
+}
+
+$breakpoint-s: var(--breakpoint-s);
+$breakpoint-m: var(--breakpoint-m);
+$breakpoint-l: var(--breakpoint-l);
 
 @mixin s {
   @media (max-width: #{$breakpoint-s}) {


### PR DESCRIPTION
I discovered that in the current implementation, it is not possible to use your own breakpoints, as they are hard-coded in the SCSS file. This fix allows you to overwrite variables and make it work as intended.