### PR TITLE
fix: resolve TurbopackInternalError - Next.js package not found

### DIFF
--- a/apps/dev/next.config.js
+++ b/apps/dev/next.config.js
@@ -1,11 +1,17 @@
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  transpilePackages: ['@once-ui-system/core'],
+  transpilePackages: ["@once-ui-system/core"],
   reactStrictMode: true,
-  turbopack: { },
+  turbopack: {},
   webpack: (config) => {
     return config;
-  }
+  },
+  outputFileTracingRoot: path.join(__dirname, "../../"),
 };
 
-module.exports = nextConfig;
+export default nextConfig;

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -1,4 +1,8 @@
 import mdx from "@next/mdx";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const withMDX = mdx({
   extension: /\.mdx?$/,
@@ -13,7 +17,8 @@ const nextConfig = {
     compiler: "modern",
     silenceDeprecations: ["legacy-js-api"],
   },
-  output: 'standalone',
+  output: "standalone",
+  outputFileTracingRoot: path.join(__dirname, "../../"),
 };
 
 export default withMDX(nextConfig);

--- a/packages/core/next.config.mjs
+++ b/packages/core/next.config.mjs
@@ -1,9 +1,14 @@
 /** @type {import('next').NextConfig} */
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const nextConfig = {
   sassOptions: {
     compiler: "modern",
     silenceDeprecations: ["legacy-js-api"],
   },
+  outputFileTracingRoot: path.join(__dirname, "../../"),
 };
 
 export default nextConfig;


### PR DESCRIPTION
https://github.com/vercel/next.js/issues/74226

This occurs when next.js cannot trace file dependencies in monorepo setups
