### PR TITLE
feat: add documentation for MasonryGrid component with usage examples

### DIFF
--- a/apps/docs/src/content/once-ui/components/masonryGrid.mdx
+++ b/apps/docs/src/content/once-ui/components/masonryGrid.mdx
@@ -1,0 +1,205 @@
+---
+title: "MasonryGrid"
+summary: "The MasonryGrid component arranges items in a masonry layout, optimizing space and creating a visually appealing grid."
+updatedAt: "2025-09-06"
+docs: "once-ui/components/masonryGrid.mdx"
+github: "components/MasonryGrid.tsx"
+navLabel: "MasonryGrid"
+navIcon: "components"
+navTag: "New"
+navTagVariant: "cyan"
+---
+
+A component that arranges items in a masonry layout, optimizing space and creating a visually appealing grid. Ideal for displaying images, cards, or any content with varying heights.
+
+## MasonryGrid
+
+<CodeBlock
+    marginTop="16"
+    marginBottom="24"
+    previewPadding="0"
+    preview={
+        <MasonryGrid
+            padding="l"
+            radius="l"
+            background="neutral-medium"
+            columns={6}
+            m={{ columns: 4 }}
+            s={{ columns: 2 }}
+        >
+            {[16, 6, 4, 6, 16, 12, 7, 24, 4, 12, 6, 2, 24, 17, 12, 5, 9, 6, 20, 11].map((height, index) => (
+                <Flex
+                    key={index}
+                    background="overlay"
+                    radius="l"
+                    border="neutral-alpha-medium"
+                    fill
+                    center
+                    height={height}
+                >{index}
+                </Flex>
+            ))}
+        </MasonryGrid>
+    }
+    codes={[
+        {
+            code:
+                `<MasonryGrid
+    padding="l"
+    radius="l"
+    background="neutral-medium"
+    columns={6}
+    m={{ columns: 4 }}
+    s={{ columns: 2 }}
+>
+    {[16, 6, 4, 6, 16, 12, 7, 24, 4, 12, 6, 2, 24, 17, 12, 5, 9, 6, 20, 11].map((height, index) => (
+        <Flex
+            key={index}
+            background="overlay"
+            radius="l"
+            border="neutral-alpha-medium"
+            fill
+            center
+            height={height}
+        >{index}
+        </Flex>
+    ))}
+</MasonryGrid>`,
+            language: "tsx",
+            label: "MasonryGrid"
+        }
+    ]}
+/>
+
+## Columns
+
+Control the number of columns in the grid using the `columns` prop. You can also set different column counts for various screen sizes using responsive props like `l`, `m` and `s`.
+
+<CodeBlock
+    marginTop="16"
+    marginBottom="24"
+    previewPadding="0"
+    preview={
+        <MasonryGrid
+            padding="l"
+            radius="l"
+            background="neutral-medium"
+            columns={4}
+            m={{ columns: 2 }}
+            s={{ columns: 1 }}
+        >
+            {[16, 6, 4, 6, 16, 12, 7, 24, 4, 12, 6, 2].map((height, index) => (
+                <Flex
+                    key={index}
+                    background="overlay"
+                    radius="l"
+                    border="neutral-alpha-medium"
+                    fill
+                    center
+                    height={height}
+                >{index}
+                </Flex>
+            ))}
+        </MasonryGrid>
+    }
+    codes={[
+        {
+            code:
+                `<MasonryGrid
+    padding="l"
+    radius="l"
+    background="neutral-medium"
+    columns={4}
+    m={{ columns: 2 }}
+    s={{ columns: 1 }}
+>
+    {[16, 6, 4, 6, 16, 12, 7, 24, 4, 12, 6, 2].map((height, index) => (
+        <Flex
+            key={index}
+            background="overlay"
+            radius="l"
+            border="neutral-alpha-medium"
+            fill
+            center
+            height={height}
+        >{index}
+        </Flex>
+    ))}
+</MasonryGrid>`,
+            language: "tsx",
+            label: "MasonryGrid"
+        }
+    ]}
+/>
+
+## Gap
+
+Adjust the spacing between items using the `gap` prop.
+
+<CodeBlock
+    marginTop="16"
+    marginBottom="24"
+    previewPadding="0"
+    preview={
+        <MasonryGrid
+            padding="l"
+            radius="l"
+            background="neutral-medium"
+            columns={4}
+            gap={"16"}
+        >
+            {[16, 6, 4, 6, 16, 12, 7, 24, 4, 12, 6, 2].map((height, index) => (
+                <Flex
+                    key={index}
+                    background="overlay"
+                    radius="l"
+                    border="neutral-alpha-medium"
+                    fill
+                    center
+                    height={height}
+                >{index}
+                </Flex>
+            ))}
+        </MasonryGrid>
+    }
+    codes={[
+        {
+            code:
+                `<MasonryGrid
+    padding="l"
+    radius="l"
+    background="neutral-medium"
+    columns={4}
+    gap={"16"}
+>
+    {[16, 6, 4, 6, 16, 12, 7, 24, 4, 12, 6, 2].map((height, index) => (
+        <Flex
+            key={index}
+            background="overlay"
+            radius="l"
+            border="neutral-alpha-medium"
+            fill
+            center
+            height={height}
+        >{index}
+        </Flex>
+    ))}
+</MasonryGrid>`,
+            language: "tsx",
+            label: "MasonryGrid"
+        }
+    ]}
+/>
+
+## API reference
+
+<PropsTable
+    content={[
+        ["columns", "number", "3"],
+        ["gap", "SpacingToken", "8"],
+        ["className"],
+        ["style"],
+        ["children"],
+        ["...flex"]
+    ]}
+/>


### PR DESCRIPTION
Added documentation for the `MasonryGrid` component.  #13 