### PR TITLE
fix(animation): forward flex props

### DIFF
--- a/packages/core/src/components/Animation.tsx
+++ b/packages/core/src/components/Animation.tsx
@@ -354,6 +354,7 @@ const Animation = forwardRef<HTMLDivElement, AnimationProps>(
                 onMouseEnter={triggerType === "hover" ? handleMouseEnter : undefined}
                 onMouseLeave={triggerType === "hover" ? handleMouseLeave : undefined}
                 aria-hidden={!isActive}
+                {...flex}
               >
                 {children}
               </Flex>,


### PR DESCRIPTION
When the `trigger` and `portal` props were used together in the `Animation` component, the rest of the props (`...flex`) were not forwarded to the `Flex` wrapper of the portal content.

As a result, attempts to style the floating content wrapper of components such as HoverCard via `...flex` did not work as expected.

This change forwards the `{...flex}` props to the `Flex` component inside the portal, ensuring that styles are applied as intended.