### PR TITLE
fix: add radius prop to RevealFx component in Carousel

### DIFF
--- a/packages/core/src/components/Carousel.tsx
+++ b/packages/core/src/components/Carousel.tsx
@@ -210,6 +210,7 @@ const Carousel: React.FC<CarouselProps> = ({
       <RevealFx
         fillWidth
         fillHeight={fill}
+        radius={rest.radius || "l"}
         trigger={isTransitioning}
         translateY={translateY}
         aspectRatio={aspectRatio === "original" ? undefined : aspectRatio}


### PR DESCRIPTION
This would match the radius on the image. On bright images (and dark theme) you can see the radius disappearing and a sharp corner appears during the transition.

https://github.com/user-attachments/assets/5d5718df-c858-47f0-9b50-335c67fb4315

