### PR TITLE
fix: add 'type' prop to Text component

### DIFF
--- a/apps/docs/src/content/once-ui/components/text.mdx
+++ b/apps/docs/src/content/once-ui/components/text.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Text"
 summary: "A flexible typography component for rendering inline or block text with configurable font styles, spacing, and color."
-updatedAt: "2025-05-09"
+updatedAt: "2026-03-07"
 docs: "once-ui/components/text.mdx"
 github: "components/Text.tsx"
 navLabel: "Text"
@@ -19,7 +19,7 @@ The `Text` component provides consistent typography throughout your UI, with sup
     <Column gap="12">
       <Text variant="body-default-m">This is default body text.</Text>
       <Text variant="label-strong-s">This is a strong label.</Text>
-      <Text size="s" weight="strong">This is small, strong text.</Text>
+      <Text size="s" weight="strong" type="body">This is small, strong text.</Text>
     </Column>
   }
   codes={[
@@ -31,7 +31,7 @@ The `Text` component provides consistent typography throughout your UI, with sup
 <Text variant="label-strong-s">
   This is a strong label.
 </Text>
-<Text size="s" weight="strong">
+<Text size="s" weight="strong" type="body">
   This is small, strong text.
 </Text>`,
       language: "tsx",
@@ -324,6 +324,7 @@ Control the rendered tag using the `as` prop.
     ["variant", "TextVariant"],
     ["size", ["xs", "s", "m", "l", "xl"]],
     ["weight", ["default", "strong"]],
+    ["type", ["display", "heading", "body", "label", "code"]],
     ["family", ["display", "heading", "body", "label", "code"]],
     ["onBackground", "`${ColorScheme}-${ColorWeight}`"],
     ["onSolid", "`${ColorScheme}-${ColorWeight}`"],

--- a/packages/core/src/components/Text.tsx
+++ b/packages/core/src/components/Text.tsx
@@ -14,6 +14,7 @@ const Text = <T extends ElementType = "span">({
   variant,
   size,
   weight,
+  type,
   family,
   onBackground,
   onSolid,
@@ -41,8 +42,8 @@ const Text = <T extends ElementType = "span">({
 }: TypeProps<T>) => {
   const Component = as || "span";
 
-  if (variant && (size || weight)) {
-    console.warn("When 'variant' is set, 'size' and 'weight' are ignored.");
+  if (variant && (size || weight || type)) {
+    console.warn("When 'variant' is set, 'size', 'type' and 'weight' are ignored.");
   }
 
   if (onBackground && onSolid) {
@@ -56,10 +57,11 @@ const Text = <T extends ElementType = "span">({
     return [`font-${fontType}`, `font-${weight}`, `font-${size}`];
   };
 
+  const typeClass = type ? `font-${type}` : "";
   const sizeClass = size ? `font-${size}` : "";
   const weightClass = weight ? `font-${weight}` : "";
 
-  const classes = variant ? getVariantClasses(variant) : [sizeClass, weightClass];
+  const classes = variant ? getVariantClasses(variant) : [typeClass, sizeClass, weightClass];
 
   let colorClass = "";
   if (onBackground) {

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -69,6 +69,7 @@ export interface TextProps<T extends ElementType = "span"> extends HTMLAttribute
   wrap?: CSSProperties["textWrap"];
   size?: TextSize;
   weight?: TextWeight;
+  type?: TextType;
   truncate?: boolean;
 }
 


### PR DESCRIPTION
The simplest solution that does not break backward compatibility with existing projects. #45 

Without a fix:
<img width="221" height="93" src="https://github.com/user-attachments/assets/a5ef544b-5544-428d-a667-2dff79ef5793" />

With a fix:
<img width="226" height="110" src="https://github.com/user-attachments/assets/184e059e-e121-481b-8b99-aefdf5f8c842" />

What was the error: When setting styles via size and weight, the element itself did not receive any styles, since the classes referred to by the above parameters exist only within font type classes.