### PR TITLE
feat(media): support numeric sizes shorthand

### DIFF
--- a/apps/docs/src/content/once-ui/components/media.mdx
+++ b/apps/docs/src/content/once-ui/components/media.mdx
@@ -39,6 +39,40 @@ navIcon: "components"
   ]}
 />
 
+## Sizes shorthand
+
+You can pass a number to `sizes` for a common responsive pattern.
+
+`sizes={768}` expands to `(max-width: 768px) 100vw, 768px`.
+
+<CodeBlock
+  marginTop="16"
+  marginBottom="24"
+  preview={
+    <Media
+      sizes={768}
+      src="/images/docs/once-ui/vibe-coding-light.jpg"
+      alt="Preview"
+      radius="xl"
+      border="neutral-alpha-medium"
+    />
+  }
+  codes={[
+    {
+      code:
+`<Media
+    src="/image.jpg"
+    alt="Preview"
+    sizes={768}
+    radius="xl"
+    border="neutral-alpha-medium"
+/>`,
+      language: "tsx",
+      label: "Sizes shorthand"
+    }
+  ]}
+/>
+
 ## Loading
 
 Show a skeleton block while content is loading. Only works when `aspectRatio` is specified.
@@ -240,7 +274,7 @@ The component auto-detects and renders YouTube links, just pass a YouTube URL to
     ["enlarge", "boolean", "false"],
     ["priority", "boolean"],
     ["unoptimized", "boolean"],
-    ["sizes", "string", "100vw"],
+    ["sizes", ["string", "number"], "100vw"],
     ["className"],
     ["style"],
     ["...flex"]

--- a/packages/core/src/components/Media.tsx
+++ b/packages/core/src/components/Media.tsx
@@ -14,7 +14,7 @@ export interface MediaProps extends React.ComponentProps<typeof Flex> {
   enlarge?: boolean;
   src: string;
   unoptimized?: boolean;
-  sizes?: string;
+  sizes?: string | number;
   priority?: boolean;
   caption?: ReactNode;
   fill?: boolean;
@@ -131,6 +131,10 @@ const Media: React.FC<MediaProps> = ({
 
   const isVideo = src?.endsWith(".mp4");
   const isYouTube = isYouTubeVideo(src);
+  const resolvedSizes =
+    typeof sizes === "number"
+      ? `(max-width: ${sizes}px) 100vw, ${sizes}px`
+      : sizes;
 
   return (
     <>
@@ -208,7 +212,7 @@ const Media: React.FC<MediaProps> = ({
             <Image
               src={src}
               alt={alt}
-              sizes={isEnlarged ? "100vw" : sizes}
+              sizes={isEnlarged ? "100vw" : resolvedSizes}
               priority={priority}
               unoptimized={unoptimized}
               fill={fill || !aspectRatio}


### PR DESCRIPTION
Use this PR draft.

PR Title
[FEATURE] Sizes shorthand for Media

PR Body
## Summary
This PR adds shorthand numeric support for the Media sizes prop so that passing a number produces the same responsive behavior as the longer Next.js sizes string format.

Fixes #60

## Why this change
Many Media use-cases need the same pattern:
(max-width: Npx) 100vw, Npx

Before this change, authors had to write the full string every time.  
With this update, sizes can now be passed as a number for the same behavior and cleaner usage.

## What changed
1. Added numeric sizes support in packages/core/src/components/Media.tsx.
2. Updated the Media prop type from string to string | number in packages/core/src/components/Media.tsx.
3. Added shorthand documentation and example in apps/docs/src/content/once-ui/components/media.mdx.
4. Updated Media API docs for sizes type in apps/docs/src/content/once-ui/components/media.mdx.

## Behavior details
1. sizes={768} now resolves to:
(max-width: 768px) 100vw, 768px
2. Existing string input behavior is unchanged.
3. Enlarged Media behavior remains unchanged and still uses 100vw while enlarged.

## Scope and impact
1. Focused, low-risk change.
2. No breaking API changes for existing string users.
3. No changes to unrelated components or styles.

## Testing and validation

### Automated checks
1. PASS: npx pnpm@10.14.0 --filter @once-ui-system/core typecheck
2. PASS: npx pnpm@10.14.0 --filter @once-ui-system/core build
3. PASS: npx pnpm@10.14.0 --filter @once-ui-system/docs build
4. PASS: npx pnpm@10.14.0 --filter @once-ui-system/docs lint
5. PASS: npx pnpm@10.14.0 --filter @once-ui-system/dev build

### Browser-level automated assertions (Playwright)
1. Loaded /once-ui/components/media in docs app.
2. Verified Sizes shorthand section is rendered.
3. Verified rendered img sizes value for shorthand example equals:
(max-width: 768px) 100vw, 768px
4. Verified Fill example still renders sizes as:
240px
5. Verified rendered sizes set includes:
(max-width: 768px) 100vw, 768px, 100vw, and 240px
6. Playwright result: PASS

### Notes from validation
1. One unrelated pre-existing warning remains in docs lint/build at apps/docs/src/app/api/og/generate/route.tsx regarding img alt text.
2. During dev build validation, a stale local build artifact in .next initially caused a false failure for an old deleted route; after cleaning local cache, dev build passed.

## Files changed
1. packages/core/src/components/Media.tsx
2. apps/docs/src/content/once-ui/components/media.mdx

## Validation screenshot
<img width="1919" height="1006" alt="image" src="https://github.com/user-attachments/assets/2a325478-2953-4e3e-8b35-19a366d1b164" />


## Maintainer note
If anything looks off, or if additional context on implementation choices is useful, I am happy to clarify and iterate quickly in this PR thread.