### PR TITLE
fix: prevent page scroll jump on Textarea auto-resize

### DIFF
--- a/packages/core/src/components/Textarea.tsx
+++ b/packages/core/src/components/Textarea.tsx
@@ -74,8 +74,10 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
 
     const adjustHeight = () => {
       if (textareaRef.current) {
+        const scrollY = window.scrollY;
         textareaRef.current.style.height = "auto";
-        textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`; // Set to scroll height
+        textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
+        window.scrollTo({ top: scrollY });
       }
     };
 


### PR DESCRIPTION
Capture and restore window.scrollY around the height recalculation in adjustHeight to stop the browser from scrolling to the bottom on every keystroke when lines="auto" and the page has a scrollbar.