### PR TITLE
feat: add closeOnClickaway prop to Dialog

### DIFF
--- a/packages/core/src/components/Dialog.tsx
+++ b/packages/core/src/components/Dialog.tsx
@@ -26,6 +26,7 @@ interface DialogProps extends Omit<React.ComponentProps<typeof Flex>, "title"> {
   stack?: boolean;
   onHeightChange?: (height: number) => void;
   minHeight?: number;
+  closeOnClickaway?: boolean;
 }
 
 const DialogContext = React.createContext<{
@@ -56,6 +57,7 @@ export const DialogProvider: React.FC<{
 const Dialog: React.FC<DialogProps> = forwardRef<HTMLDivElement, DialogProps>(
   (
     {
+      closeOnClickaway = true,
       isOpen,
       onClose,
       title,
@@ -257,6 +259,8 @@ const Dialog: React.FC<DialogProps> = forwardRef<HTMLDivElement, DialogProps>(
         }
 
         if (!dialogRef.current?.contains(event.target as Node)) {
+          if (!closeOnClickaway) return;
+          
           if (stack || !base) {
             event.preventDefault();
             onClose();


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h2 data-start="81" data-end="91">Summary</h2>
<p data-start="93" data-end="246">This PR adds a new optional <code data-start="121" data-end="139">closeOnClickaway</code> prop to the <code data-start="152" data-end="160">Dialog</code> component, allowing control over whether clicking outside the dialog should close it.</p>
<p data-start="248" data-end="362">It also improves UX consistency for cases where interactive overlays (e.g. toasts) are used inside an open dialog.</p>
<hr data-start="364" data-end="367">
<h2 data-start="369" data-end="379">Changes</h2>
<ul data-start="381" data-end="652">
<li data-start="381" data-end="439">
Added <code data-start="389" data-end="417">closeOnClickaway?: boolean</code> prop to <code data-start="426" data-end="439">DialogProps</code>
</li>
<li data-start="440" data-end="491">
Default value set to <code data-start="463" data-end="469">true</code> (backward compatible)
</li>
<li data-start="492" data-end="652">
Updated clickaway handler to respect the new prop:
<ul data-start="547" data-end="652">
<li data-start="547" data-end="604">
When <code data-start="554" data-end="561">false</code>, outside clicks no longer close the dialog
</li>
<li data-start="607" data-end="652">
When <code data-start="614" data-end="620">true</code>, existing behavior is preserved
</li>
</ul>
</li>
</ul>
<hr data-start="654" data-end="657">
<h2 data-start="659" data-end="670">Behavior</h2>
<div class="TyagGW_tableContainer"><div tabindex="-1" class="group TyagGW_tableWrapper flex flex-col-reverse w-fit">
closeOnClickaway | Behavior
-- | --
true (default) | Clicking outside closes dialog (existing behavior)
false | Clicking outside does not close dialog

</div></div>
<hr data-start="873" data-end="876">
<h2 data-start="878" data-end="891">Motivation</h2>
<p data-start="893" data-end="1091">In some UI flows, dialogs may contain additional interactive elements (e.g. toast notifications or nested overlays). In these cases, accidental dialog closing due to outside clicks leads to poor UX.</p>
<p data-start="1093" data-end="1183">This prop provides explicit control over that behavior without changing existing defaults.</p>
<hr data-start="1185" data-end="1188">
<h2 data-start="1190" data-end="1198">Notes</h2>
<ul data-start="1200" data-end="1322">
<li data-start="1200" data-end="1227">
Fully backward compatible
</li>
<li data-start="1228" data-end="1249">
No breaking changes
</li>
<li data-start="1250" data-end="1286">
Default behavior remains unchanged
</li>
<li data-start="1287" data-end="1322">
Scoped only to clickaway handling</li></ul><!--EndFragment-->
</body>
</html>