### PR TITLE
fix(Option): set width:100% on label/description spans for ellipsis

### DIFF
--- a/packages/core/src/components/Option.tsx
+++ b/packages/core/src/components/Option.tsx
@@ -164,27 +164,11 @@ const Option = forwardRef<HTMLDivElement, OptionProps>(
           {...flex}
         >
           {hasPrefix && <Row className={styles.prefix}>{hasPrefix}</Row>}
-          <Column
-            horizontal="start"
-            style={{
-              minWidth: 0,
-              whiteSpace: "nowrap",
-            }}
-            fillWidth
-          >
+          <Column fillWidth align="left">
             <Text
               onBackground="neutral-strong"
               variant="label-default-s"
-              // `width: 100%` is required for ellipsis to engage: without
-              // it the span is shrink-to-fit and `overflow: hidden` has
-              // nothing to clip against. `minWidth: 0` on the parent
-              // Column lets this 100% actually constrain to available
-              // space inside a flex row.
-              style={{
-                width: "100%",
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-              }}
+              truncate
             >
               {label || children}
             </Text>
@@ -192,11 +176,7 @@ const Option = forwardRef<HTMLDivElement, OptionProps>(
               <Text
                 variant="body-default-xs"
                 onBackground="neutral-weak"
-                style={{
-                  width: "100%",
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                }}
+                truncate
               >
                 {description}
               </Text>

--- a/packages/core/src/components/Option.tsx
+++ b/packages/core/src/components/Option.tsx
@@ -167,15 +167,37 @@ const Option = forwardRef<HTMLDivElement, OptionProps>(
           <Column
             horizontal="start"
             style={{
+              minWidth: 0,
               whiteSpace: "nowrap",
             }}
             fillWidth
           >
-            <Text onBackground="neutral-strong" variant="label-default-s">
+            <Text
+              onBackground="neutral-strong"
+              variant="label-default-s"
+              // `width: 100%` is required for ellipsis to engage: without
+              // it the span is shrink-to-fit and `overflow: hidden` has
+              // nothing to clip against. `minWidth: 0` on the parent
+              // Column lets this 100% actually constrain to available
+              // space inside a flex row.
+              style={{
+                width: "100%",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+              }}
+            >
               {label || children}
             </Text>
             {description && (
-              <Text variant="body-default-xs" onBackground="neutral-weak">
+              <Text
+                variant="body-default-xs"
+                onBackground="neutral-weak"
+                style={{
+                  width: "100%",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                }}
+              >
                 {description}
               </Text>
             )}


### PR DESCRIPTION
Truncation wouldn't engage on long labels because the inner Text spans were shrink-to-fit — overflow:hidden had nothing to clip against. Adding minWidth:0 to the surrounding Column (so the 100% can constrain inside the flex row) and width:100% + overflow:hidden + textOverflow on each Text span makes long option labels ellipsize cleanly.