### PR TITLE
fix(core): lazy-load optional dependencies for CodeBlock and MediaUpload

### DIFF
--- a/packages/core/src/components/Dialog.tsx
+++ b/packages/core/src/components/Dialog.tsx
@@ -26,6 +26,7 @@ interface DialogProps extends Omit<React.ComponentProps<typeof Flex>, "title"> {
   stack?: boolean;
   onHeightChange?: (height: number) => void;
   minHeight?: number;
+  closeOnClickaway?: boolean;
 }
 
 const DialogContext = React.createContext<{
@@ -56,6 +57,7 @@ export const DialogProvider: React.FC<{
 const Dialog: React.FC<DialogProps> = forwardRef<HTMLDivElement, DialogProps>(
   (
     {
+      closeOnClickaway = true,
       isOpen,
       onClose,
       title,
@@ -257,6 +259,8 @@ const Dialog: React.FC<DialogProps> = forwardRef<HTMLDivElement, DialogProps>(
         }
 
         if (!dialogRef.current?.contains(event.target as Node)) {
+          if (!closeOnClickaway) return;
+          
           if (stack || !base) {
             event.preventDefault();
             onClose();

--- a/packages/core/src/modules/code/CodeBlock.impl.tsx
+++ b/packages/core/src/modules/code/CodeBlock.impl.tsx
@@ -4,7 +4,6 @@ import React, { ReactNode, RefObject, useEffect, useRef, useState } from "react"
 import ReactDOM from "react-dom";
 import classNames from "classnames";
 import { SpacingToken } from "../../types";
-import Prism from "prismjs";
 import styles from "./CodeBlock.module.scss";
 import {
   Flex,
@@ -16,6 +15,15 @@ import {
   Column,
   Text,
 } from "../../components";
+
+let Prism: any;
+
+async function getPrism() {
+  if (!Prism) {
+    Prism = (await import("prismjs")).default;
+  }
+  return Prism;
+}
 
 const loadCssFiles = async () => {
   if (typeof window !== "undefined") {
@@ -284,6 +292,7 @@ const renderDiff = (
   startLineNumber: number | undefined,
   codeRef: RefObject<HTMLElement | null>,
   lang: string | undefined,
+  prism: any,
 ) => {
   const parsedLines = parseDiff(diffContent, startLineNumber);
 
@@ -292,13 +301,13 @@ const renderDiff = (
   // Apply syntax highlighting to code lines
   let highlightedLines: string[] = [];
   
-  if (lang && Prism.languages[lang]) {
+  if (lang && prism.languages[lang]) {
     try {
       highlightedLines = codeLines.map((line) => {
         try {
           // Check if language is loaded before highlighting
-          if (Prism.languages[lang]) {
-            return Prism.highlight(line.content, Prism.languages[lang], lang);
+          if (prism.languages[lang]) {
+            return prism.highlight(line.content, prism.languages[lang], lang);
           }
           return line.content;
         } catch (error) {
@@ -323,9 +332,9 @@ const renderDiff = (
         let className = "";
 
         if (isInformationalLine(line.type)) {
-          if (Prism.languages.diff) {
+          if (prism.languages.diff) {
             try {
-              content = Prism.highlight(line.content, Prism.languages.diff, "diff");
+              content = prism.highlight(line.content, prism.languages.diff, "diff");
             } catch (error) {
               console.warn(`Failed to highlight diff line: ${line.content}`, error);
             }
@@ -414,6 +423,7 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
   const [isAnimating, setIsAnimating] = useState(false);
   const codeBlockRef = useRef<HTMLDivElement>(null);
   const [dependenciesLoaded, setDependenciesLoaded] = useState(false);
+  const [prismInstance, setPrismInstance] = useState<any>(null);
 
   const codeInstance = codes[selectedInstance] || {
     code: "",
@@ -434,6 +444,8 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
         ),
         loadCssFiles(),
       ]);
+      const resolvedPrism = await getPrism();
+      setPrismInstance(resolvedPrism);
       setDependenciesLoaded(true);
     };
 
@@ -442,7 +454,8 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
 
   useEffect(() => {
     if (dependenciesLoaded && codeRef.current && codes.length > 0) {
-      setTimeout(() => {
+      setTimeout(async () => {
+        const Prism = await getPrism();
         Prism.highlightAll();
       }, 0);
     }
@@ -486,7 +499,8 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
       Array.isArray(codeInstance.language) &&
       codeInstance.language.includes("diff")
     ) {
-      const timeoutId = setTimeout(() => {
+      const timeoutId = setTimeout(async () => {
+        const Prism = await getPrism();
         if (codeRef.current) {
           const diffRows = codeRef.current.querySelectorAll(".diff-row");
           const lang = codeInstance.language[1];
@@ -547,7 +561,8 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
       setSelectedInstance(index);
 
       // Re-highlight after tab change
-      setTimeout(() => {
+      setTimeout(async () => {
+        const Prism = await getPrism();
         Prism.highlightAll();
       }, 10);
     }
@@ -557,11 +572,12 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
     if (isFullscreen) {
       // When exiting fullscreen, first remove animation class, then remove portal after transition
       setIsAnimating(false);
-      setTimeout(() => {
+      setTimeout(async () => {
         setIsFullscreen(false);
 
         // Re-highlight after exiting fullscreen
-        setTimeout(() => {
+        setTimeout(async () => {
+          const Prism = await getPrism();
           Prism.highlightAll();
         }, 10);
       }, 300); // Match transition duration
@@ -570,7 +586,8 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
       setIsFullscreen(true);
 
       // Re-highlight after entering fullscreen
-      setTimeout(() => {
+      setTimeout(async () => {
+        const Prism = await getPrism();
         Prism.highlightAll();
       }, 50);
     }
@@ -580,7 +597,8 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
   useEffect(() => {
     if (isAnimating && dependenciesLoaded) {
       // Re-highlight after animation completes
-      setTimeout(() => {
+      setTimeout(async () => {
+        const Prism = await getPrism();
         Prism.highlightAll();
       }, 350); // Slightly longer than animation duration
     }
@@ -742,11 +760,12 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
                 )}
                 style={{ maxHeight: `${codeHeight}rem`, overflow: "auto", width: "100%" }}
               >
-                {renderDiff(
+                {prismInstance && renderDiff(
                   typeof code === "string" ? code : code.content,
                   startLineNumber,
                   codeRef,
                   Array.isArray(language) ? language[1] : undefined,
+                  prismInstance,
                 )}
               </div>
             ) : (

--- a/packages/core/src/modules/media/MediaUpload.impl.tsx
+++ b/packages/core/src/modules/media/MediaUpload.impl.tsx
@@ -1,9 +1,17 @@
 "use client";
 
 import React, { useRef, useState, forwardRef, useEffect } from "react";
-import Compressor from "compressorjs";
 import { Flex, Icon, Media, Spinner, Text } from "../../";
 import styles from "./MediaUpload.module.scss";
+
+let Compressor: any;
+
+async function getCompressor() {
+  if (!Compressor) {
+    Compressor = (await import("compressorjs")).default;
+  }
+  return Compressor;
+}
 
 export interface MediaUploadProps extends React.ComponentProps<typeof Flex> {
   onFileUpload?: (file: File) => Promise<void>;
@@ -103,19 +111,21 @@ const MediaUpload = forwardRef<HTMLInputElement, MediaUploadProps>(
       }
     };
 
-    const compressImage = (file: File) => {
+    const compressImage = async (file: File) => {
+      const Compressor = (await getCompressor()).default ?? (await getCompressor());
+
       new Compressor(file, {
-        convertTypes: convertTypes,
-        quality: quality,
+        convertTypes,
+        quality,
         maxWidth: resizeMaxWidth,
         maxHeight: resizeMaxHeight,
         convertSize: 400 * 1024,
         width: resizeWidth,
         height: resizeHeight,
-        success(compressedFile) {
-          uploadFile(compressedFile as File);
+        success(compressedFile: File) {
+          uploadFile(compressedFile);
         },
-        error(err) {
+        error(err: unknown) {
           console.error("Compression error:", err);
           uploadFile(file);
         },


### PR DESCRIPTION
## Summary

This PR fixes a Next.js/Turbopack module resolution issue caused by optional dependencies being statically imported in core components.

### Problem
The following dependencies were being imported statically:
- prismjs (used in CodeBlock)
- compressorjs (used in MediaUpload)

This caused build failures in projects using @once-ui-system/core without explicitly installing these dependencies, even if the affected components were not used.

### Solution
- Removed static imports of `prismjs` and `compressorjs`
- Replaced them with lazy-loaded dynamic imports
- Ensured dependencies are only loaded when the relevant components are actually used

### Result
- Core package no longer forces optional dependency installation
- Downstream projects can use unaffected components without additional installs
- Build compatibility with Next.js/Turbopack improved

### Safety
<img width="1008" height="613" alt="Screenshot_7" src="https://github.com/user-attachments/assets/ba8dbf1f-4a77-4574-9f37-95f7dcf05b21" />
