### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is the **Once UI** monorepo (pnpm workspaces + Turborepo). It is frontend-only:
+a publishable React/Next.js design system plus two Next.js apps. There is **no database,
+auth, backend, or secrets** — nothing external needs to be provisioned.
+
+Workspaces:
+- `packages/core` (`@once-ui-system/core`) — the design system library (the product). Built with `tsc` + `sass` to `dist/`.
+- `apps/dev` — Next.js 16 sandbox for developing/testing components (primary contributor playground; see `CONTRIBUTING.md`).
+- `apps/docs` — Next.js 15 documentation site.
+
+### Environment / setup notes
+- Node: the repo declares `engines.node: 20.x`, but the VM ships Node 22 (LTS). There is **no `engine-strict`**, and Next 15/16 both support Node 22, so the harmless `Unsupported engine` warning during install can be ignored.
+- `pnpm install` builds `packages/core` automatically via the `apps/docs` `postinstall` hook, so `dist/` is ready after install. If the apps ever fail to resolve `@once-ui-system/core`, rebuild it with `pnpm --filter @once-ui-system/core build`.
+- To live-iterate on the library while running an app, run `pnpm --filter @once-ui-system/core dev` (tsc watch) alongside the app.
+- The root `dev:core` script uses `bun`, which is **not installed**. Use the pnpm flow instead (`cd apps/dev && pnpm dev`).
+
+### Running the apps (dev mode)
+- `apps/dev`: `cd apps/dev && pnpm dev` → http://localhost:3000
+- `apps/docs`: `cd apps/docs && pnpm dev` → also defaults to port 3000. **Both apps use port 3000**, so when running both at once give one a different port, e.g. `pnpm dev --port 3001`. (Running root `pnpm dev` / `turbo dev` starts both and will collide on 3000.)
+
+### Tests / lint (standard commands live in each `package.json`)
+- Tests: `pnpm --filter @once-ui-system/core test` (Vitest). Note: 4 tests (`Dialog` inert + `ScrollLock` wheel) currently fail under the pinned jsdom (68/72 pass); this is a pre-existing jsdom-behavior issue, not an env problem.
+- Lint, pre-existing breakage to be aware of (do not "fix" as part of env setup):
+  - `pnpm --filter @once-ui-system/core lint` (Biome) fails because `biome.json` files use the `1.9.4` schema while the pinned CLI is `2.4.13` (unknown keys `ignore`, `organizeImports`).
+  - `apps/dev` `pnpm lint` fails because its script is `next lint`, which was removed in Next 16.
+  - `apps/docs` `pnpm lint` (Next 15) works and reports no errors.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for the Once UI monorepo (pnpm workspaces + Turborepo, frontend-only — no DB/auth/secrets). Adds `AGENTS.md` with durable, non-obvious notes for future cloud agents.

- Dependencies install via `pnpm install` (builds `packages/core` automatically through the `apps/docs` `postinstall` hook).
- Verified both dev servers run and the design system is interactive end-to-end.

## Environment

- **Update script:** `pnpm install`
- **Node:** repo declares `engines.node: 20.x`; VM uses Node 22 (LTS). No `engine-strict`, and Next 15/16 support Node 22, so the engine warning is harmless.

## What was run

| Workspace | Command | Result |
|---|---|---|
| `packages/core` | `pnpm build` (via install postinstall) | ✅ builds `dist/` |
| `packages/core` | `pnpm test` (Vitest) | ⚠️ 68/72 pass; 4 pre-existing jsdom-behavior failures (`Dialog` inert, `ScrollLock` wheel) |
| `packages/core` | `pnpm lint` (Biome) | ❌ pre-existing: `biome.json` uses 1.9.4 schema, CLI is 2.4.13 |
| `apps/dev` | `pnpm dev` → :3000 | ✅ Ready, HTTP 200, interactive |
| `apps/dev` | `pnpm lint` | ❌ pre-existing: `next lint` removed in Next 16 |
| `apps/docs` | `pnpm dev --port 3001` | ✅ Ready, HTTP 200 |
| `apps/docs` | `pnpm lint` | ✅ no errors |

Note: both apps default to port 3000; run one on a different port when running both.

## Hello-world demo

Interacted with the Once UI component sandbox at `localhost:3000`: toggled a Switch, opened/closed a Dialog, typed into a text input, and viewed the animated `CountFx` counter reach 3,000.

[once_ui_dev_app_demo.mp4](https://cursor.com/agents/bc-00f92e08-ac90-4f82-956f-462c084bb838/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fonce_ui_dev_app_demo.mp4)

[Components showcase](https://cursor.com/agents/bc-00f92e08-ac90-4f82-956f-462c084bb838/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdev_app_components_showcase.webp)
[Dialog open](https://cursor.com/agents/bc-00f92e08-ac90-4f82-956f-462c084bb838/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdev_app_dialog_open.webp)
[Counter page](https://cursor.com/agents/bc-00f92e08-ac90-4f82-956f-462c084bb838/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdev_app_counter.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-00f92e08-ac90-4f82-956f-462c084bb838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00f92e08-ac90-4f82-956f-462c084bb838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

