### PR TITLE
chore: sync AI harness artifacts to core 1.7.12

### DIFF
--- a/packages/core/ai/catalog.json
+++ b/packages/core/ai/catalog.json
@@ -1,5 +1,5 @@
 {
- "version": "1.7.11",
+ "version": "1.7.12",
  "generated": "2026-07-05",
  "components": {
   "Accordion": {

--- a/packages/core/ai/manifest.json
+++ b/packages/core/ai/manifest.json
@@ -1,5 +1,5 @@
 {
- "version": "1.7.11",
+ "version": "1.7.12",
  "generated": "2026-07-05",
  "files": {
   "spec": "spec.json",

--- a/packages/core/ai/spec.json
+++ b/packages/core/ai/spec.json
@@ -1,6 +1,6 @@
 {
  "name": "@once-ui-system/core",
- "version": "1.7.11",
+ "version": "1.7.12",
  "generated": "2026-07-05",
  "format": "props are 'type', 'type = default', or '!type' (required). Components with 'mixins' also accept all props of those mixins. 'extends' means all props of that component are accepted.",
  "tokens": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to the `1.7.12` core version bump: updates the agent-facing AI harness artifacts (`catalog.json`, `manifest.json`, `spec.json`) so their `version` fields match the published package.

## Context

The previous bump commit updated `packages/core/package.json` only. These generated files were still pinned at `1.7.12` → now aligned after running `pnpm generate-ai-spec`.

## Changes

- `packages/core/ai/catalog.json` — version `1.7.11` → `1.7.12`
- `packages/core/ai/manifest.json` — version `1.7.11` → `1.7.12`
- `packages/core/ai/spec.json` — version `1.7.11` → `1.7.12`

No functional or API changes — metadata sync only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91d6405c-2a37-444e-8a0b-9d7ca9e83575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91d6405c-2a37-444e-8a0b-9d7ca9e83575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

