### PR TITLE
feat(dev): compact agent activity UI in AI chat

### DIFF
--- a/apps/dev/src/app/(main)/chat/page.tsx
+++ b/apps/dev/src/app/(main)/chat/page.tsx
@@ -2,6 +2,12 @@
 
 import { useEffect, useRef, useState } from "react";
 import {
+  AgentActivityBar,
+  AgentGeneration,
+  type AgentUpdate,
+  type ToolCall,
+} from "@/components/agent-chat";
+import {
   Avatar,
   Column,
   EmojiPickerDropdown,
@@ -120,6 +126,26 @@ const history: Message[] = [
 
 const STREAM_REPLY =
   "Pulling the deployment checklist — builds are green, e2e passed, and the canary is at 12% with no error spike. Safe to promote when you're ready.";
+
+const AGENT_TOOL_CALLS: ToolCall[] = [
+  { id: "tc-1", name: "Read", detail: "apps/dev/src/app/(main)/chat/page.tsx" },
+  { id: "tc-2", name: "Read", detail: "packages/core/src/components/Dialog.tsx" },
+  { id: "tc-3", name: "Read", detail: "packages/core/src/components/Accordion.tsx" },
+  { id: "tc-4", name: "Grep", detail: "accordion|tool|generation" },
+  { id: "tc-5", name: "Grep", detail: "ToolCall|AgentActivity" },
+  { id: "tc-6", name: "Edit", detail: "apps/dev/src/app/(main)/chat/page.tsx" },
+  { id: "tc-7", name: "Shell", detail: "pnpm --filter @once-ui-system/core test" },
+];
+
+const AGENT_UPDATES: AgentUpdate[] = [
+  { id: "u-1", time: "9:41:02", message: "Read apps/dev/src/app/(main)/chat/page.tsx" },
+  { id: "u-2", time: "9:41:03", message: "Read packages/core/src/components/Dialog.tsx" },
+  { id: "u-3", time: "9:41:04", message: "Read packages/core/src/components/Accordion.tsx" },
+  { id: "u-4", time: "9:41:05", message: 'Grep "accordion|tool|generation"' },
+  { id: "u-5", time: "9:41:06", message: 'Grep "ToolCall|AgentActivity"' },
+  { id: "u-6", time: "9:41:08", message: "Edit apps/dev/src/app/(main)/chat/page.tsx" },
+  { id: "u-7", time: "9:41:10", message: "Shell pnpm --filter @once-ui-system/core test" },
+];
 
 function UnreadCount({ count }: { count: number }) {
   return (
@@ -255,30 +281,32 @@ function MessageRow({
   );
 }
 
-function StreamingMessage({ text, active }: { text: string; active: boolean }) {
+function AgentMessage({
+  text,
+  active,
+  toolCalls,
+  updates,
+}: {
+  text: string;
+  active: boolean;
+  toolCalls: ToolCall[];
+  updates: AgentUpdate[];
+}) {
   return (
     <Row gap="12" paddingX="20" paddingY="16">
       <Column width={8} horizontal="start">
         <Avatar size="m" value="AI" icon="sparkle" />
       </Column>
-      <Column flex={1} gap="4" minWidth={0}>
+      <Column flex={1} gap="8" minWidth={0}>
         <Row gap="8" vertical="center">
           <Text variant="label-strong-s">Nexus AI</Text>
           <Text variant="label-default-xs" onBackground="neutral-weak">
             now
           </Text>
-          {active && <Spinner size="xs" ariaLabel="Nexus AI is responding" />}
+          {active ? <Spinner size="xs" ariaLabel="Nexus AI is responding" /> : null}
         </Row>
-        <Column maxWidth={48}>
-          <Text variant="body-default-s" onBackground="neutral-strong">
-            {text}
-            {active && (
-              <Text as="span" onBackground="brand-medium">
-                ▍
-              </Text>
-            )}
-          </Text>
-        </Column>
+        <AgentActivityBar toolCalls={toolCalls} updates={updates} />
+        <AgentGeneration text={text} active={active} />
       </Column>
     </Row>
   );
@@ -299,6 +327,8 @@ export default function ChatPage() {
   const [draft, setDraft] = useState("");
   const [streamedText, setStreamedText] = useState("");
   const [isStreaming, setIsStreaming] = useState(true);
+  const [visibleToolCalls, setVisibleToolCalls] = useState<ToolCall[]>([]);
+  const [visibleUpdates, setVisibleUpdates] = useState<AgentUpdate[]>([]);
   const [clearedUnread, setClearedUnread] = useState<Record<string, boolean>>({});
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
@@ -308,13 +338,30 @@ export default function ChatPage() {
     if (!activeConversation.isAi) return;
 
     let index = 0;
+    let toolIndex = 0;
+    let updateIndex = 0;
     setStreamedText("");
+    setVisibleToolCalls([]);
+    setVisibleUpdates([]);
     setIsStreaming(true);
 
     const interval = window.setInterval(() => {
       index += 1;
       setStreamedText(STREAM_REPLY.slice(0, index));
+
+      if (index % 18 === 0 && toolIndex < AGENT_TOOL_CALLS.length) {
+        setVisibleToolCalls((prev) => [...prev, AGENT_TOOL_CALLS[toolIndex]]);
+        toolIndex += 1;
+      }
+
+      if (index % 24 === 0 && updateIndex < AGENT_UPDATES.length) {
+        setVisibleUpdates((prev) => [...prev, AGENT_UPDATES[updateIndex]]);
+        updateIndex += 1;
+      }
+
       if (index >= STREAM_REPLY.length) {
+        setVisibleToolCalls(AGENT_TOOL_CALLS);
+        setVisibleUpdates(AGENT_UPDATES);
         setIsStreaming(false);
         window.clearInterval(interval);
       }
@@ -325,7 +372,7 @@ export default function ChatPage() {
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [streamedText, isStreaming, activeId]);
+  }, [streamedText, isStreaming, visibleToolCalls.length, visibleUpdates.length, activeId]);
 
   const handleSelect = (id: string) => {
     setActiveId(id);
@@ -440,7 +487,12 @@ export default function ChatPage() {
                         }}
                         showHeader
                       />
-                      <StreamingMessage text={streamedText} active={isStreaming} />
+                      <AgentMessage
+                        text={streamedText}
+                        active={isStreaming}
+                        toolCalls={visibleToolCalls}
+                        updates={visibleUpdates}
+                      />
                     </>
                   ) : (
                     history.map((message, index) => {

--- a/apps/dev/src/components/agent-chat/AgentActivityBar.tsx
+++ b/apps/dev/src/components/agent-chat/AgentActivityBar.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+import { IconButton, Row } from "@once-ui-system/core";
+import { AgentUpdatesDialog } from "./AgentUpdatesDialog";
+import { ToolCallGroup } from "./ToolCallGroup";
+import type { AgentUpdate, ToolCall, ToolCallGroup as ToolCallGroupType } from "./types";
+import { groupToolCalls } from "./utils";
+
+type AgentActivityBarProps = {
+  toolCalls: ToolCall[];
+  updates: AgentUpdate[];
+};
+
+export function AgentActivityBar({ toolCalls, updates }: AgentActivityBarProps) {
+  const [logOpen, setLogOpen] = useState(false);
+  const [dialogTitle, setDialogTitle] = useState("Activity log");
+  const [dialogUpdates, setDialogUpdates] = useState<AgentUpdate[]>(updates);
+  const groups = groupToolCalls(toolCalls);
+
+  const openLog = (nextUpdates: AgentUpdate[], title = "Activity log") => {
+    setDialogUpdates(nextUpdates);
+    setDialogTitle(title);
+    setLogOpen(true);
+  };
+
+  const handleGroupSelect = (group: ToolCallGroupType) => {
+    const detailUpdates = group.items.map((item) => ({
+      id: item.id,
+      time: "",
+      message: item.detail ? `${item.name}: ${item.detail}` : item.name,
+    }));
+
+    openLog(
+      detailUpdates,
+      group.count > 1 ? `${group.name} (${group.count})` : group.name,
+    );
+  };
+
+  if (groups.length === 0 && updates.length === 0) return null;
+
+  return (
+    <>
+      <Row gap="8" vertical="center" wrap>
+        <ToolCallGroup groups={groups} onSelect={handleGroupSelect} />
+        {updates.length > 0 ? (
+          <IconButton
+            icon="document"
+            variant="tertiary"
+            size="s"
+            tooltip="Log"
+            aria-label="Open activity log"
+            onClick={() => openLog(updates)}
+          />
+        ) : null}
+      </Row>
+
+      <AgentUpdatesDialog
+        isOpen={logOpen}
+        onClose={() => setLogOpen(false)}
+        updates={dialogUpdates}
+        title={dialogTitle}
+      />
+    </>
+  );
+}

--- a/apps/dev/src/components/agent-chat/AgentGeneration.tsx
+++ b/apps/dev/src/components/agent-chat/AgentGeneration.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Column, Text } from "@once-ui-system/core";
+
+type AgentGenerationProps = {
+  text: string;
+  active?: boolean;
+};
+
+export function AgentGeneration({ text, active = false }: AgentGenerationProps) {
+  if (!text && !active) return null;
+
+  return (
+    <Column
+      maxWidth={48}
+      maxHeight={12}
+      overflowY="auto"
+      background="neutral-alpha-weak"
+      radius="m"
+      paddingX="12"
+      paddingY="8"
+      border="neutral-alpha-weak"
+    >
+      <Text variant="body-default-s" onBackground="neutral-strong">
+        {text}
+        {active ? (
+          <Text as="span" onBackground="brand-medium">
+            ▍
+          </Text>
+        ) : null}
+      </Text>
+    </Column>
+  );
+}

--- a/apps/dev/src/components/agent-chat/AgentUpdatesDialog.tsx
+++ b/apps/dev/src/components/agent-chat/AgentUpdatesDialog.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Column, Dialog, Line, Row, Text } from "@once-ui-system/core";
+import type { AgentUpdate } from "./types";
+
+type AgentUpdatesDialogProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  updates: AgentUpdate[];
+  title?: string;
+};
+
+export function AgentUpdatesDialog({
+  isOpen,
+  onClose,
+  updates,
+  title = "Activity log",
+}: AgentUpdatesDialogProps) {
+  return (
+    <Dialog isOpen={isOpen} onClose={onClose} title={title} minHeight={24}>
+      <Column gap="8" paddingTop="4">
+        {updates.length === 0 ? (
+          <Text variant="body-default-s" onBackground="neutral-weak">
+            No activity yet.
+          </Text>
+        ) : (
+          updates.map((update, index) => (
+            <Column key={update.id} gap="8">
+              <Row gap="12" vertical="start">
+                <Text variant="label-default-xs" onBackground="neutral-weak" wrap="nowrap">
+                  {update.time}
+                </Text>
+                <Text variant="body-default-s" onBackground="neutral-strong">
+                  {update.message}
+                </Text>
+              </Row>
+              {index < updates.length - 1 ? <Line /> : null}
+            </Column>
+          ))
+        )}
+      </Column>
+    </Dialog>
+  );
+}

--- a/apps/dev/src/components/agent-chat/ToolCallGroup.tsx
+++ b/apps/dev/src/components/agent-chat/ToolCallGroup.tsx
@@ -10,11 +10,14 @@ type ToolCallGroupProps = {
 };
 
 export function ToolCallGroup({ groups, onSelect }: ToolCallGroupProps) {
-  if (groups.length === 0) return null;
+  if (!groups || groups.length === 0) return null;
 
   return (
     <Row gap="4" wrap>
       {groups.map((group) => {
+        // Defensive: skip if group doesn't have required properties
+        if (!group || !group.name) return null;
+        
         const label = group.count > 1 ? `${group.name} ×${group.count}` : group.name;
 
         return (

--- a/apps/dev/src/components/agent-chat/ToolCallGroup.tsx
+++ b/apps/dev/src/components/agent-chat/ToolCallGroup.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Button, Row } from "@once-ui-system/core";
+import type { ToolCallGroup as ToolCallGroupType } from "./types";
+import { toolCallIcon } from "./utils";
+
+type ToolCallGroupProps = {
+  groups: ToolCallGroupType[];
+  onSelect?: (group: ToolCallGroupType) => void;
+};
+
+export function ToolCallGroup({ groups, onSelect }: ToolCallGroupProps) {
+  if (groups.length === 0) return null;
+
+  return (
+    <Row gap="4" wrap>
+      {groups.map((group) => {
+        const label = group.count > 1 ? `${group.name} ×${group.count}` : group.name;
+
+        return (
+          <Button
+            key={`${group.name}-${group.items[0]?.id}`}
+            size="s"
+            variant="secondary"
+            prefixIcon={toolCallIcon(group.name)}
+            onClick={() => onSelect?.(group)}
+          >
+            {label}
+          </Button>
+        );
+      })}
+    </Row>
+  );
+}

--- a/apps/dev/src/components/agent-chat/index.ts
+++ b/apps/dev/src/components/agent-chat/index.ts
@@ -1,0 +1,6 @@
+export { AgentActivityBar } from "./AgentActivityBar";
+export { AgentGeneration } from "./AgentGeneration";
+export { AgentUpdatesDialog } from "./AgentUpdatesDialog";
+export { ToolCallGroup } from "./ToolCallGroup";
+export type { AgentUpdate, ToolCall, ToolCallGroup as ToolCallGroupData } from "./types";
+export { groupToolCalls, toolCallIcon } from "./utils";

--- a/apps/dev/src/components/agent-chat/types.ts
+++ b/apps/dev/src/components/agent-chat/types.ts
@@ -1,0 +1,18 @@
+export type ToolCall = {
+  id: string;
+  name: string;
+  detail?: string;
+  status?: "pending" | "done";
+};
+
+export type ToolCallGroup = {
+  name: string;
+  count: number;
+  items: ToolCall[];
+};
+
+export type AgentUpdate = {
+  id: string;
+  time: string;
+  message: string;
+};

--- a/apps/dev/src/components/agent-chat/utils.ts
+++ b/apps/dev/src/components/agent-chat/utils.ts
@@ -5,6 +5,9 @@ export function groupToolCalls(calls: ToolCall[]): ToolCallGroup[] {
   const groups: ToolCallGroup[] = [];
 
   for (const call of calls) {
+    // Defensive: skip if call doesn't have a name
+    if (!call || !call.name) continue;
+    
     const last = groups[groups.length - 1];
     if (last && last.name === call.name) {
       last.count += 1;

--- a/apps/dev/src/components/agent-chat/utils.ts
+++ b/apps/dev/src/components/agent-chat/utils.ts
@@ -1,0 +1,40 @@
+import type { IconName } from "@once-ui-system/core";
+import type { ToolCall, ToolCallGroup } from "./types";
+
+export function groupToolCalls(calls: ToolCall[]): ToolCallGroup[] {
+  const groups: ToolCallGroup[] = [];
+
+  for (const call of calls) {
+    const last = groups[groups.length - 1];
+    if (last && last.name === call.name) {
+      last.count += 1;
+      last.items.push(call);
+      continue;
+    }
+
+    groups.push({
+      name: call.name,
+      count: 1,
+      items: [call],
+    });
+  }
+
+  return groups;
+}
+
+export function toolCallIcon(name: string): IconName {
+  switch (name) {
+    case "Read":
+      return "eye";
+    case "Grep":
+      return "search";
+    case "Edit":
+    case "Write":
+    case "StrReplace":
+      return "clipboard";
+    case "Shell":
+      return "computer";
+    default:
+      return "document";
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves the dev sandbox AI chat thread (`#design-system`) with a more compact agent activity display:

- **Grouped tool calls** — consecutive calls of the same type collapse into small secondary buttons with a count (e.g. `Read ×3`, `Grep ×2`) in a single row
- **Activity log dialog** — replaces an accordion-style updates list with a compact document icon (`tooltip: Log`) that opens a dialog with timestamped activity entries
- **Contained generation** — streaming agent output is wrapped in a `neutral-alpha-weak` panel with padding, radius, border, and `maxHeight={12}` scroll overflow

## Implementation

New components under `apps/dev/src/components/agent-chat/`:

- `ToolCallGroup` — renders grouped tool call buttons
- `AgentActivityBar` — single-row activity bar (tool buttons + log icon)
- `AgentUpdatesDialog` — modal activity log
- `AgentGeneration` — contained streaming text panel

The AI thread in `apps/dev/src/app/(main)/chat/page.tsx` simulates progressive tool call / update reveal during streaming.

## Test plan

- [x] Open `http://localhost:3000/chat` and select `# design-system`
- [x] Verify grouped tool buttons appear in one row during streaming
- [x] Click Log icon → activity dialog opens with timestamped entries
- [x] Verify agent text streams inside the contained alpha-weak panel
- [x] `pnpm exec tsc --noEmit` in `apps/dev` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3125162f-4581-4184-87df-14652ef6f11c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3125162f-4581-4184-87df-14652ef6f11c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

