### PR TITLE
Add Once UI Learn Phase 1 content

### DIFF
--- a/content/once-ui-learn/README.md
+++ b/content/once-ui-learn/README.md
@@ -23,17 +23,15 @@ DOPLER_API_TOKEN=av_live_... node content/once-ui-learn/upload.mjs
 
 Uploads draft MDX to the Once UI Learn site. Review and publish in the Aveiro editor.
 
-## Pages (Phase 1)
+## Pages (Phase 1 + 2)
 
-1. Once UI Learn (home)
-2. What is Once UI?
-3. Install & config
-4. Your first page
-5. Semantics over CSS
-6. Row, Column & Grid
-7. Spacing & rhythm
-8. Color & surfaces
-9. Typography scale
-10. Page skeleton
-11. Column, not Flex
-12. Harness overview
+**Start & foundations** (12 pages) — orientation, layout, spacing, color, typography, tips, agents.
+
+**Common patterns** (6 pages):
+
+1. Static panel
+2. Hero section
+3. Form layout
+4. Decoration layers
+5. Highlighted card
+6. Responsive stacking

--- a/content/once-ui-learn/README.md
+++ b/content/once-ui-learn/README.md
@@ -1,0 +1,39 @@
+# Once UI Learn — content source
+
+Phase 1 lesson drafts for the [Once UI Learn](https://aveiro.app) Aveiro site (`learn-once-ui`).
+
+## Structure
+
+| Local folder | Aveiro path | Track |
+|--------------|-------------|-------|
+| `index.mdx` | `/index.mdx` | Homepage |
+| `start/` | flat `/*.mdx` | Getting started |
+| `foundations/` | flat `/*.mdx` | Core concepts |
+| `patterns/` | flat `/*.mdx` | Reusable compositions |
+| `tips/` | flat `/*.mdx` | Quick posts |
+| `for-agents/` | flat `/*.mdx` | Agent harness |
+
+> Aveiro API v1 requires sidebar folders to be created in the editor. Pages are uploaded as flat paths; organize into groups in Aveiro after publishing.
+
+## Upload
+
+```bash
+DOPLER_API_TOKEN=av_live_... node content/once-ui-learn/upload.mjs
+```
+
+Uploads draft MDX to the Once UI Learn site. Review and publish in the Aveiro editor.
+
+## Pages (Phase 1)
+
+1. Once UI Learn (home)
+2. What is Once UI?
+3. Install & config
+4. Your first page
+5. Semantics over CSS
+6. Row, Column & Grid
+7. Spacing & rhythm
+8. Color & surfaces
+9. Typography scale
+10. Page skeleton
+11. Column, not Flex
+12. Harness overview

--- a/content/once-ui-learn/for-agents/harness-overview.mdx
+++ b/content/once-ui-learn/for-agents/harness-overview.mdx
@@ -1,0 +1,89 @@
+<Feedback title="8 min · For agents" description="Load rules.compact.md + a task bundle (~8KB), not full doc pages. Generate, then validate mechanically." variant="info" />
+
+## Bootstrap (always)
+
+Before any UI codegen task, load these two files:
+
+```
+@once-ui-system/core/ai/rules.compact.md    (~2KB)
+@once-ui-system/core/ai/catalog.json        (component index)
+```
+
+Or from the docs site:
+
+- [rules.compact.md](https://docs.once-ui.com/ai/rules.compact.md)
+- [catalog.json](https://docs.once-ui.com/ai/catalog.json)
+
+Entry point listing all artifacts: [manifest.json](https://docs.once-ui.com/ai/manifest.json)
+
+## Route by intent
+
+Match the user's request to a task bundle via [tasks/index.json](https://docs.once-ui.com/ai/tasks/index.json):
+
+| Intent | Task bundle |
+|--------|-------------|
+| Marketing hero | `tasks/marketing-hero.json` |
+| Pricing page | `tasks/pricing.json` |
+| Settings panel | `tasks/settings.json` |
+| Dashboard | `tasks/dashboard.json` |
+| Chat interface | `tasks/chat.json` |
+| Auth flow | `tasks/auth.json` |
+| Roadmap | `tasks/roadmap.json` |
+
+Each bundle lists: required components, recipes, gotchas, quality targets, and Pro block references.
+
+## Progressive loading
+
+Don't load everything. Per task:
+
+1. `rules.compact.md` — layout, surfaces, typography, motion rules
+2. Task bundle — component list + gotcha keys
+3. Component slices — `ai/components/{Name}.json` on demand
+4. Recipes — `recipes.md` sections referenced by the task
+5. Gotchas — `gotchas.json` entries for components you'll use
+6. Pro blocks — `examples/blocks/manifest.json` for production fidelity
+
+**Target: under ~10KB context per task**, not full doc pages.
+
+## Workflow
+
+```
+1. Load rules.compact.md
+2. Resolve intent → pick task bundle
+3. Fetch component slices listed in the bundle
+4. Read gold example / Pro block for structure
+5. Generate TSX
+6. Validate: pnpm validate-ai-code path/to/file.tsx
+```
+
+## What validate-ai-code catches
+
+- `Flex direction=` → should be Row/Column
+- `fillWidth fillHeight` → should be `fill`
+- Hex/rgb colors → should be token props
+- Invented icon names → must match `IconName` in spec
+- Default props that should be omitted
+
+## Context budget
+
+| Load | Size | When |
+|------|------|------|
+| `rules.compact.md` | ~2KB | Always |
+| `catalog.json` | ~4KB | Component selection |
+| Task bundle | ~1KB | Intent matched |
+| Component slice | ~0.5KB each | On demand |
+| Full doc page | 10–50KB | **Avoid for codegen** |
+
+## Humans vs agents
+
+| Need | Use |
+|------|-----|
+| "How do I think about layout?" | Once UI Learn (this site) |
+| "What props does Grid accept?" | docs.once-ui.com reference |
+| "Build me a pricing page" | Harness task bundles |
+
+## Related
+
+→ [What is Once UI?](/what-is-once-ui.mdx)
+→ [Column, not Flex](/column-not-flex.mdx)
+→ Full harness docs: [docs.once-ui.com/once-ui/ai-coding](https://docs.once-ui.com/once-ui/ai-coding)

--- a/content/once-ui-learn/foundations/color-and-surfaces.mdx
+++ b/content/once-ui-learn/foundations/color-and-surfaces.mdx
@@ -1,0 +1,90 @@
+<Feedback title="6 min · Beginner · Foundations" description="Static panels use Column + surface props. Card is for interactive surfaces only." variant="info" />
+
+## Color schemes
+
+Colors follow `{scheme}-{weight}` or `{scheme}-alpha-{weight}`:
+
+| Scheme | Use for |
+|--------|---------|
+| `neutral` | Text, borders, subtle backgrounds |
+| `brand` | Primary accent, CTAs, highlights |
+| `accent` | Secondary accent (sparingly) |
+| `danger` / `warning` / `success` / `info` | Status and feedback |
+
+Weights: `weak`, `medium`, `strong`. Alpha variants (`brand-alpha-medium`) are for overlays and glows.
+
+Background shortcuts: `surface`, `overlay`, `page`, `transparent`.
+
+## The static panel recipe
+
+For pricing tiers, stats, settings sections — anything **not clickable**:
+
+```text
+<Column
+  background="surface"
+  border="neutral-alpha-weak"
+  radius="l"
+  padding="24"
+  gap="16"
+  fill
+>
+  <Heading variant="heading-strong-m">Panel title</Heading>
+  <Text variant="body-default-s" onBackground="neutral-weak">
+    Panel body
+  </Text>
+</Column>
+```
+
+This is the workhorse pattern. Memorize it.
+
+## Card is interactive only
+
+`Card` is for surfaces with `href` or `onClick` — clickable tiles, links, selectable items.
+
+| Surface type | Component |
+|--------------|-----------|
+| Static panel | `Column` + surface recipe |
+| Clickable tile | `Card href="..."` or `Card onClick` |
+| Button action | `Button` |
+
+Using `Card` for a non-interactive box is one of the most common Once UI mistakes.
+
+## Text on colored backgrounds
+
+Use `onBackground` to set text color relative to the parent:
+
+```text
+<Column background="brand-medium" padding="24" radius="l">
+  <Text variant="body-default-m" onBackground="brand-weak">
+    Light text on brand background
+  </Text>
+</Column>
+```
+
+## Write this / not this
+
+| ✅ Once UI way | ❌ Common mistake |
+|----------------|-------------------|
+| `background="surface"` | `background: "#f5f5f5"` |
+| `border="neutral-alpha-weak"` | `border: 1px solid #e5e5e5` |
+| `Column` + surface props | `<Card>` for static content |
+| `onBackground="neutral-weak"` | Hardcoded text color |
+
+## Decoration colors
+
+For glows and gradients, prefer alpha tokens:
+
+- `brand-alpha-medium` — glows, ambient layers
+- `neutral-alpha-weak` — dot textures, subtle overlays
+
+Never mix multiple accent families in decoration on one page.
+
+## Check yourself
+
+- [ ] Static panels use the surface recipe on `Column`
+- [ ] `Card` only appears with `href` or `onClick`
+- [ ] No hex/rgb colors anywhere
+
+## Next step
+
+→ [Typography scale](/typography-scale.mdx)

--- a/content/once-ui-learn/foundations/layout-row-column-grid.mdx
+++ b/content/once-ui-learn/foundations/layout-row-column-grid.mdx
@@ -1,0 +1,88 @@
+<Feedback title="8 min · Beginner · Foundations" description="Row and Column are your defaults. Flex is for dynamic direction. Grid is for columns." variant="info" />
+
+## Decision tree
+
+```
+Need layout?
+├── Vertical stack     → Column
+├── Horizontal row     → Row
+├── Direction changes at breakpoints → Flex (or Row/Column with s={{ direction }})
+└── Multi-column grid  → Grid
+```
+
+## Row and Column
+
+Thin wrappers around `Flex` with fixed direction. **Always prefer these** for static layouts:
+
+```text
+<Column gap="16">
+  <Heading variant="display-strong-s">Title</Heading>
+  <Text variant="body-default-m" onBackground="neutral-weak">Body</Text>
+</Column>
+
+<Row gap="16" vertical="center">
+  <Icon name="check" />
+  <Text variant="body-default-s">Aligned row</Text>
+</Row>
+```
+
+## Flex — only when direction changes
+
+Use `Flex` (or responsive props on `Row`/`Column`) when layout flips at breakpoints:
+
+```text
+<Row gap="24" s={{ direction: "column" }}>
+  <Column fill>Left panel</Column>
+  <Column fill>Right panel</Column>
+</Row>
+```
+
+Breakpoint props: `xl`, `l`, `m`, `s`, `xs` — larger breakpoints cascade down. Never write media queries for layout.
+
+## Grid
+
+For explicit column counts:
+
+```text
+<Grid columns="3" gap="24" s={{ columns: "1" }}>
+  <Column>Item 1</Column>
+  <Column>Item 2</Column>
+  <Column>Item 3</Column>
+</Grid>
+```
+
+## Alignment shorthands
+
+| Shorthand | Expands to |
+|-----------|------------|
+| `center` | `horizontal="center" vertical="center"` |
+| `fill` | `fillWidth fillHeight` |
+| `fit` | `fitWidth fitHeight` |
+
+## Write this / not this
+
+| ✅ Once UI way | ❌ Common mistake |
+|----------------|-------------------|
+| `Column` with `gap="16"` | `Flex` with `direction="column"` |
+| `Row` with `gap="16"` | `Flex` with `direction="row"` |
+| `center` | `horizontal="center" vertical="center"` |
+| `s={{ direction: "column" }}` | `@media (max-width: 768px) { flex-direction: column }` |
+
+## Other layout components
+
+| Component | When to use |
+|-----------|-------------|
+| `MasonryGrid` | Pinterest-style variable-height columns |
+| `SplitView` | Resizable two-pane (chat, settings) |
+| `Scroller` | Horizontal scroll regions |
+| `LogoCloud` | Logo grid — always set `columns` |
+
+## Check yourself
+
+- [ ] Static vertical layout uses `Column`, not `Flex direction="column"`
+- [ ] Static horizontal layout uses `Row`
+- [ ] Responsive layout uses breakpoint props, not CSS media queries
+
+## Next step
+
+→ [Spacing & rhythm](/spacing-and-rhythm.mdx)

--- a/content/once-ui-learn/foundations/semantics-over-css.mdx
+++ b/content/once-ui-learn/foundations/semantics-over-css.mdx
@@ -1,0 +1,79 @@
+<Feedback title="5 min · Beginner · Foundations" description="Once UI props map to design tokens — not arbitrary CSS. This is what makes code predictable for humans and agents." variant="info" />
+
+## The idea
+
+In Once UI, you style by **meaning**, not by value:
+
+- `gap="16"` — spacing from the token scale
+- `background="surface"` — semantic surface color
+- `onBackground="neutral-weak"` — text color that contrasts with the parent
+
+You almost never write `style={{ ... }}`, class names, or hex colors. The prop *is* the design decision.
+
+## Token scales
+
+**Spacing** — fixed steps, not free-form pixels:
+
+```
+"0" "1" "2" "4" "8" "12" "16" "20" "24" "32" "40" "48" "56" "64" "80" "104" "128" "160"
+```
+
+**Colors** — scheme + weight:
+
+```
+neutral-weak    brand-medium    danger-strong
+neutral-alpha-weak    brand-alpha-medium
+```
+
+Also: `surface`, `overlay`, `page`, `transparent` for backgrounds.
+
+**Typography** — type + weight + size:
+
+```
+display-strong-l    heading-strong-m    body-default-s    label-default-xs
+```
+
+## Props on layout components
+
+Style surfaces directly on `Row`, `Column`, `Grid` — no wrapper needed:
+
+```text
+<Column
+  background="surface"
+  border="neutral-alpha-weak"
+  radius="l"
+  padding="24"
+  gap="16"
+  textVariant="label-default-s"
+  onBackground="neutral-weak"
+>
+  Panel content without nesting Text for simple labels
+</Column>
+```
+
+## Write this / not this
+
+| ✅ Once UI way | ❌ Common mistake |
+|----------------|-------------------|
+| `background="brand-medium"` | `background: "#3b82f6"` |
+| `gap="24"` | `gap: 22` or `gap: "1.5rem"` |
+| `textVariant="display-strong-l"` | `fontSize: 32, fontWeight: 700` |
+| `onBackground="neutral-weak"` | `color: "#666"` |
+
+## Why agents care
+
+The codegen harness (`spec.json`) encodes every valid token. When you use semantic props:
+
+1. Agents can't invent invalid colors or spacing
+2. `validate-ai-code` catches hex/rgb and wrong flex patterns
+3. Refactors are prop renames, not CSS archaeology
+
+## Check yourself
+
+- [ ] No hex, rgb, or hsl in generated code
+- [ ] Spacing values come from the token scale
+- [ ] Text on layout uses `textVariant` + `onBackground` when possible
+
+## Next step
+
+→ [Row, Column & Grid](/layout-row-column-grid.mdx)

--- a/content/once-ui-learn/foundations/spacing-and-rhythm.mdx
+++ b/content/once-ui-learn/foundations/spacing-and-rhythm.mdx
@@ -1,0 +1,66 @@
+<Feedback title="5 min · Beginner · Foundations" description="Once UI spacing is rhythmic: 104 between sections, 24–40 inside sections, and a fixed token scale everywhere else." variant="info" />
+
+## Section rhythm
+
+The most important spacing rule in Once UI:
+
+| Context | Gap token | Notes |
+|---------|-----------|-------|
+| Between major sections | `"104"` | Hero → features → CTA |
+| Inside a section | `"24"`–`"40"` | Heading → body → actions |
+| Tight groups | `"8"`–`"16"` | Icon + label, form fields |
+| Page vertical padding | `paddingY="80"` | Top/bottom breathing room |
+
+**Never** use `"48"` between major sections — it breaks the vertical rhythm.
+
+## Page example
+
+```text
+<Column as="main" fillWidth horizontal="center">
+  <Column maxWidth="l" paddingY="80" gap="104" fillWidth>
+    {/* Section 1 */}
+    <Column gap="24">...</Column>
+
+    {/* Section 2 — 104px gap applied automatically */}
+    <Column gap="32">...</Column>
+
+    {/* Section 3 */}
+    <Column gap="24">...</Column>
+  </Column>
+</Column>
+```
+
+The outer `gap="104"` handles section separation. Inner `gap="24"` or `gap="32"` handles content within each section.
+
+## Padding vs gap
+
+- **`gap`** — space *between* children in a flex/grid container
+- **`padding`** / **`paddingX`** / **`paddingY`** — space *inside* a container's border
+- **`marginTop`** / **`marginBottom`** — escape hatch; prefer `gap` on the parent
+
+## Responsive spacing
+
+Spacing props accept the same breakpoint keys as layout:
+
+```text
+<Column gap="24" s={{ gap: "16" }}>
+```
+
+## Write this / not this
+
+| ✅ Once UI way | ❌ Common mistake |
+|----------------|-------------------|
+| `gap="104"` between sections | `marginBottom: 48` |
+| `gap="24"` inside sections | Mixed arbitrary margins |
+| `padding="24"` on panels | `padding: 20` |
+| `paddingY="80"` on page content | `padding-top: 60px` |
+
+## Check yourself
+
+- [ ] Major sections separated by `gap="104"` on the parent column
+- [ ] Inner content uses `"24"`–`"40"` gaps
+- [ ] All spacing values are from the token scale
+
+## Next step
+
+→ [Color & surfaces](/color-and-surfaces.mdx)

--- a/content/once-ui-learn/foundations/typography-scale.mdx
+++ b/content/once-ui-learn/foundations/typography-scale.mdx
@@ -1,0 +1,70 @@
+<Feedback title="5 min · Beginner · Foundations" description="Once UI typography is a scale of variants — display for heroes, heading for titles, body for prose, label for eyebrows." variant="info" />
+
+## The variant scale
+
+Typography variants follow `{type}-{weight}-{size}`:
+
+| Type | Use for | Examples |
+|------|---------|----------|
+| `display` | Heroes, page titles | `display-strong-l`, `display-strong-xl` |
+| `heading` | Section titles, card headings | `heading-strong-m`, `heading-strong-s` |
+| `body` | Paragraphs, descriptions | `body-default-m`, `body-default-s` |
+| `label` | Eyebrows, captions, metadata | `label-default-s`, `label-default-xs` |
+| `code` | Inline code, monospace | `code-default-s` |
+
+Weights: `default` or `strong`. Sizes: `xs`, `s`, `m`, `l`, `xl`.
+
+## Hierarchy rules
+
+| Element | Variant |
+|---------|---------|
+| Hero headline | `display-strong-l` or `display-strong-xl` |
+| Section title | `display-strong-xs` or `display-strong-s` |
+| Card heading | `heading-strong-m` |
+| Body text | `body-default-m` or `body-default-s` |
+| Eyebrow / kicker | `label-default-s` with `onBackground="brand-medium"` |
+
+**Section titles use `display-*`, not `heading-*`.** This is a common agent mistake.
+
+## Usage
+
+On text components:
+
+```text
+<Heading variant="display-strong-l">Hero title</Heading>
+<Text variant="body-default-m" onBackground="neutral-weak">
+  Supporting paragraph.
+</Text>
+<Text variant="label-default-s" onBackground="brand-medium">
+  EYEBROW TEXT
+</Text>
+```
+
+On layout components (skip wrapping `Text` for simple cases):
+
+```text
+<Column textVariant="label-default-s" onBackground="neutral-weak">
+  Label text directly on the container
+</Column>
+```
+
+## Write this / not this
+
+| ✅ Once UI way | ❌ Common mistake |
+|----------------|-------------------|
+| `display-strong-l` for hero | `heading-strong-xl` for hero |
+| `display-strong-s` for section title | `heading-strong-l` for section title |
+| `body-default-m` for paragraphs | Custom font-size |
+| `textVariant` on layout | Nesting `Text` for every label |
+
+## Check yourself
+
+- [ ] Hero uses `display-strong-l` or larger
+- [ ] Section titles use `display-strong-xs` or `display-strong-s`
+- [ ] Body text uses `body-default-*`
+- [ ] No custom font sizes outside the variant scale
+
+## Go deeper
+
+→ [Page skeleton pattern](/page-skeleton.mdx)
+→ Full reference: [docs.once-ui.com/once-ui/basics/typography](https://docs.once-ui.com/once-ui/basics/typography)

--- a/content/once-ui-learn/index.mdx
+++ b/content/once-ui-learn/index.mdx
@@ -50,6 +50,26 @@ The grammar of Once UI. Read these before diving into individual components.
   marginBottom={2}
 />
 
+<Heading as="h2" variant="heading-strong-xl" id="patterns">
+Common patterns
+</Heading>
+
+Reusable compositions you'll reach for on every project.
+
+<Table
+  headers={["Pattern", "Time", "Topic"]}
+  rows={[
+    ["Page skeleton", "5 min", "/page-skeleton.mdx"],
+    ["Static panel", "4 min", "/static-panel.mdx"],
+    ["Hero section", "6 min", "/hero-section.mdx"],
+    ["Form layout", "5 min", "/form-layout.mdx"],
+    ["Decoration layers", "6 min", "/decoration-layers.mdx"],
+    ["Highlighted card", "5 min", "/highlighted-card.mdx"],
+    ["Responsive stacking", "5 min", "/responsive-stacking.mdx"],
+  ]}
+  marginBottom={2}
+/>
+
 <Heading as="h2" variant="heading-strong-xl" id="related">
 Go deeper
 </Heading>

--- a/content/once-ui-learn/index.mdx
+++ b/content/once-ui-learn/index.mdx
@@ -1,0 +1,59 @@
+<Column fillWidth>
+<Column fillWidth paddingTop={3} paddingBottom={3}>
+<Feedback title="In short" description="Once UI Learn teaches the mental models behind Once UI Core — layout semantics, styling tokens, and agent-friendly patterns. Start with a track below, or jump to Foundations if you're already building." variant="info" />
+</Column>
+</Column>
+
+<Heading as="h2" variant="heading-strong-xl" id="choose-your-track">
+Choose your track
+</Heading>
+
+Once UI is an **agent-first design system**: semantics over raw CSS, minimal syntax, and patterns that both humans and AI can maintain. Pick the path that matches how you work.
+
+<Table
+  headers={["Track", "For", "Start here"]}
+  rows={[
+    ["Human builder", "Designers and indie devs learning the system", "/what-is-once-ui.mdx"],
+    ["Agent operator", "Cursor, MCP, and codegen workflows", "/harness-overview.mdx"],
+    ["Quick reference", "Already know the basics — need a reminder", "/column-not-flex.mdx"],
+  ]}
+  marginBottom={2}
+/>
+
+<Heading as="h2" variant="heading-strong-xl" id="learning-path">
+Recommended path
+</Heading>
+
+Work through these in order for the fastest ramp-up:
+
+1. **[What is Once UI?](/what-is-once-ui.mdx)** — philosophy and core ideas
+2. **[Install & config](/install-and-config.mdx)** — get the package running
+3. **[Your first page](/your-first-page.mdx)** — page skeleton in 10 minutes
+4. **Foundations** — layout, spacing, color, typography
+5. **[Page skeleton pattern](/page-skeleton.mdx)** — reusable page structure
+
+<Heading as="h2" variant="heading-strong-xl" id="foundations">
+Foundations
+</Heading>
+
+The grammar of Once UI. Read these before diving into individual components.
+
+<Table
+  headers={["Lesson", "Time", "Topic"]}
+  rows={[
+    ["Semantics over CSS", "5 min", "/semantics-over-css.mdx"],
+    ["Row, Column & Grid", "8 min", "/layout-row-column-grid.mdx"],
+    ["Spacing & rhythm", "5 min", "/spacing-and-rhythm.mdx"],
+    ["Color & surfaces", "6 min", "/color-and-surfaces.mdx"],
+    ["Typography scale", "5 min", "/typography-scale.mdx"],
+  ]}
+  marginBottom={2}
+/>
+
+<Heading as="h2" variant="heading-strong-xl" id="related">
+Go deeper
+</Heading>
+
+- Full component reference: [docs.once-ui.com](https://docs.once-ui.com)
+- Agent harness (codegen): [docs.once-ui.com/once-ui/ai-coding](https://docs.once-ui.com/once-ui/ai-coding)
+- GitHub: [once-ui-system/core](https://github.com/once-ui-system/core)

--- a/content/once-ui-learn/manifest.json
+++ b/content/once-ui-learn/manifest.json
@@ -1,0 +1,90 @@
+{
+  "siteId": "bdbe103d-9204-48bf-a2f1-756deb1c2cc9",
+  "pages": [
+    {
+      "path": "/index.mdx",
+      "title": "Once UI Learn",
+      "summary": "Learn Once UI Core — semantics, layout, styling, and agent-friendly patterns for humans and AI.",
+      "contentId": "db5faad3-0ac5-4903-b6f8-5b19b7b905b6",
+      "file": "index.mdx"
+    },
+    {
+      "path": "/what-is-once-ui.mdx",
+      "title": "What is Once UI?",
+      "summary": "Philosophy and core ideas — semantics over CSS, tokens, and agent-first design.",
+      "contentId": "ccf224ed-bd76-4129-938e-fdff2667d1d5",
+      "file": "start/what-is-once-ui.mdx"
+    },
+    {
+      "path": "/install-and-config.mdx",
+      "title": "Install & config",
+      "summary": "Install @once-ui-system/core and wrap your app in providers.",
+      "contentId": "b863fe6f-a179-4583-ad07-d8f5d91be423",
+      "file": "start/install-and-config.mdx"
+    },
+    {
+      "path": "/your-first-page.mdx",
+      "title": "Your first page",
+      "summary": "Build a complete page with the Once UI skeleton in 10 minutes.",
+      "contentId": "f3555833-facd-4a13-898d-fbcd325146d8",
+      "file": "start/your-first-page.mdx"
+    },
+    {
+      "path": "/semantics-over-css.mdx",
+      "title": "Semantics over CSS",
+      "summary": "Style by meaning with design tokens — not arbitrary CSS values.",
+      "contentId": "59ccd086-a495-4562-8520-740f446d27f4",
+      "file": "foundations/semantics-over-css.mdx"
+    },
+    {
+      "path": "/layout-row-column-grid.mdx",
+      "title": "Row, Column & Grid",
+      "summary": "Layout decision tree — when to use Row, Column, Flex, and Grid.",
+      "contentId": "3158f4fd-ab54-435f-b7db-25fa32dc33c8",
+      "file": "foundations/layout-row-column-grid.mdx"
+    },
+    {
+      "path": "/spacing-and-rhythm.mdx",
+      "title": "Spacing & rhythm",
+      "summary": "Section gaps, inner gaps, and the spacing token scale.",
+      "contentId": "c2237c3f-11cc-4368-a21a-86cffb31b246",
+      "file": "foundations/spacing-and-rhythm.mdx"
+    },
+    {
+      "path": "/color-and-surfaces.mdx",
+      "title": "Color & surfaces",
+      "summary": "Color schemes, the static panel recipe, and when to use Card.",
+      "contentId": "f8360c99-7a72-4de1-8f7a-5a7938f9e22b",
+      "file": "foundations/color-and-surfaces.mdx"
+    },
+    {
+      "path": "/typography-scale.mdx",
+      "title": "Typography scale",
+      "summary": "Display, heading, body, and label variants — and when to use each.",
+      "contentId": "ea6f6b0b-0fc9-4919-8650-52f741071c5f",
+      "file": "foundations/typography-scale.mdx"
+    },
+    {
+      "path": "/page-skeleton.mdx",
+      "title": "Page skeleton",
+      "summary": "The reusable page structure every Once UI page starts from.",
+      "contentId": "be99fb15-a6bd-49af-90e0-eba82860f70c",
+      "file": "patterns/page-skeleton.mdx"
+    },
+    {
+      "path": "/column-not-flex.mdx",
+      "title": "Column, not Flex",
+      "summary": "Use Row and Column for static layouts — Flex only when direction changes.",
+      "contentId": "d0c932a5-f21e-4aee-8c17-7cdd66071a3b",
+      "file": "tips/column-not-flex.mdx"
+    },
+    {
+      "path": "/harness-overview.mdx",
+      "title": "Harness overview",
+      "summary": "Agent codegen workflow — bootstrap, task routing, and validation.",
+      "contentId": "23e701ce-e2bb-4392-97f8-e20c4dd5e9bf",
+      "file": "for-agents/harness-overview.mdx"
+    }
+  ],
+  "deletePageIds": []
+}

--- a/content/once-ui-learn/manifest.json
+++ b/content/once-ui-learn/manifest.json
@@ -72,6 +72,48 @@
       "file": "patterns/page-skeleton.mdx"
     },
     {
+      "path": "/static-panel.mdx",
+      "title": "Static panel",
+      "summary": "The surface recipe for non-interactive panels — stats, settings, feature boxes.",
+      "contentId": "b0ad2cee-989b-4361-9a9d-6b5d8ba4daa6",
+      "file": "patterns/static-panel.mdx"
+    },
+    {
+      "path": "/hero-section.mdx",
+      "title": "Hero section",
+      "summary": "Hero composition — eyebrow, headline, actions, and optional ambient glow.",
+      "contentId": "5643e79e-e159-45c5-aeff-055166d2a3c5",
+      "file": "patterns/hero-section.mdx"
+    },
+    {
+      "path": "/form-layout.mdx",
+      "title": "Form layout",
+      "summary": "Stack fields, group sections, and place actions in Once UI forms.",
+      "contentId": "2f2728ce-1ae7-4328-bcdf-05e04197c019",
+      "file": "patterns/form-layout.mdx"
+    },
+    {
+      "path": "/decoration-layers.mdx",
+      "title": "Decoration layers",
+      "summary": "Absolute Background layers, glow budget, and placement rules.",
+      "contentId": "9dfad041-5ea1-4e6e-8d92-85ec099320c5",
+      "file": "patterns/decoration-layers.mdx"
+    },
+    {
+      "path": "/highlighted-card.mdx",
+      "title": "Highlighted card",
+      "summary": "Interactive Card with brand glow for featured pricing tiers and CTAs.",
+      "contentId": "9db8372e-25c0-4fa7-bb3a-aec8cd7a4635",
+      "file": "patterns/highlighted-card.mdx"
+    },
+    {
+      "path": "/responsive-stacking.mdx",
+      "title": "Responsive stacking",
+      "summary": "Breakpoint props for mobile stacking — no media queries needed.",
+      "contentId": "182724a1-eb85-4ab5-8ae8-006f9ea77a0a",
+      "file": "patterns/responsive-stacking.mdx"
+    },
+    {
       "path": "/column-not-flex.mdx",
       "title": "Column, not Flex",
       "summary": "Use Row and Column for static layouts — Flex only when direction changes.",

--- a/content/once-ui-learn/patterns/decoration-layers.mdx
+++ b/content/once-ui-learn/patterns/decoration-layers.mdx
@@ -1,0 +1,90 @@
+<Feedback title="6 min · Pattern" description="Decoration in Once UI is layered with absolute Background components — never fighting the content, always budgeted." variant="info" />
+
+## The absolute layer rule
+
+Every decorative layer follows this template:
+
+```text
+<Background
+  position="absolute" top="0" left="0" fill pointerEvents="none"
+  gradient={{ display: true, colorStart: "brand-alpha-medium", colorEnd: "static-transparent", x: 50, y: 0, width: 150, height: 80, opacity: 60 }}
+/>
+```
+
+Content sitting above it:
+
+```text
+<Column zIndex={1} gap="24">
+  {/* your content */}
+</Column>
+```
+
+Three rules every layer must follow:
+
+1. `position="absolute" top="0" left="0"` — or it misaligns inside padded parents
+2. `pointerEvents="none"` — decoration never blocks clicks
+3. Content sibling gets `zIndex={1}`
+
+## Placement
+
+Put ambient layers on the **section wrapper**, outside any `maxWidth` column:
+
+```text
+<Column fillWidth horizontal="center" paddingY="80">
+  <Background position="absolute" top="0" left="0" fill pointerEvents="none" ... />
+  <Column zIndex={1} maxWidth="l" gap="24">
+    {/* content */}
+  </Column>
+</Column>
+```
+
+Clipping glow inside a narrow `maxWidth` container creates a hard-edged band.
+
+## Gradient units
+
+| Property | Unit | Example |
+|----------|------|---------|
+| `width` / `height` | Quarter-percent (400 = 100%) | Glows: 100–200 |
+| `x` / `y` | Percent position | `x: 50, y: 0` = top center |
+| `opacity` | 0–100 | Typical: 40–60 |
+
+## Decoration budget (hard limits)
+
+| Rule | Limit |
+|------|-------|
+| Ambient layers per section | 1 |
+| Continuous motion per page | 2 (hero + one CTA max) |
+| Accent families in decoration | 1 (`brand-*` or `neutral-*`) |
+| Sections with decoration | Anchor sections only (hero, highlight, final CTA) |
+
+Plain sections stay plain — contrast makes decorated sections feel premium.
+
+## Glow colors
+
+| ✅ Use | ❌ Avoid |
+|--------|----------|
+| `brand-alpha-medium` | `brand-background-weak` (invisible on page) |
+| `neutral-alpha-weak` | Hex or rgb values |
+| `static-transparent` as `colorEnd` | Opaque gradient ends |
+
+## Write this / not this
+
+| ✅ Once UI way | ❌ Common mistake |
+|----------------|-------------------|
+| Glow on full-bleed wrapper | Glow inside `maxWidth` column |
+| `width: 150` for soft glow | `width: 500` (blows past edges) |
+| `top="0" left="0"` on every layer | Missing position props |
+| One ambient layer per section | Every section decorated |
+
+## Check yourself
+
+- [ ] Every `Background` has `top="0" left="0" fill pointerEvents="none"`
+- [ ] Content has `zIndex={1}`
+- [ ] Glow width is 100–200
+- [ ] Only anchor sections are decorated
+
+## Related
+
+→ [Hero section](/hero-section.mdx)
+→ [Highlighted card](/highlighted-card.mdx)
+→ Full recipes: [docs.once-ui.com/ai/recipes.md](https://docs.once-ui.com/ai/recipes.md)

--- a/content/once-ui-learn/patterns/form-layout.mdx
+++ b/content/once-ui-learn/patterns/form-layout.mdx
@@ -1,0 +1,106 @@
+<Feedback title="5 min · Pattern" description="Forms in Once UI are stacked Columns with consistent gaps — label, field, helper text, grouped into sections." variant="info" />
+
+## Basic field
+
+A single form field is a vertical stack:
+
+```text
+<Column gap="8" fillWidth>
+  <Text variant="label-default-s" onBackground="neutral-weak">
+    Email address
+  </Text>
+  <Input
+    id="email"
+    placeholder="you@example.com"
+    fillWidth
+  />
+  <Text variant="body-default-xs" onBackground="neutral-weak">
+    We'll never share your email.
+  </Text>
+</Column>
+```
+
+Gap `"8"` keeps label, input, and helper tight. Use `"16"` between separate fields.
+
+## Form section
+
+Group related fields under a section title:
+
+```text
+<Column gap="24" fillWidth>
+  <Column gap="8">
+    <Heading variant="display-strong-xs">Account details</Heading>
+    <Text variant="body-default-s" onBackground="neutral-weak">
+      Update your profile information.
+    </Text>
+  </Column>
+
+  <Column gap="16" fillWidth>
+    <Column gap="8" fillWidth>
+      <Text variant="label-default-s" onBackground="neutral-weak">Name</Text>
+      <Input id="name" fillWidth />
+    </Column>
+    <Column gap="8" fillWidth>
+      <Text variant="label-default-s" onBackground="neutral-weak">Email</Text>
+      <Input id="email" type="email" fillWidth />
+    </Column>
+  </Column>
+</Column>
+```
+
+## Actions row
+
+Place submit/cancel below the fields:
+
+```text
+<Row gap="16" s={{ direction: "column" }}>
+  <Button type="submit">Save changes</Button>
+  <Button variant="secondary">Cancel</Button>
+</Row>
+```
+
+Primary action first. Stack on mobile with breakpoint props.
+
+## Inside a static panel
+
+Wrap settings forms in the surface recipe:
+
+```text
+<Column
+  background="surface"
+  border="neutral-alpha-weak"
+  radius="l"
+  padding="24"
+  gap="24"
+  fillWidth
+>
+  {/* form sections */}
+</Column>
+```
+
+## Write this / not this
+
+| ✅ Once UI way | ❌ Common mistake |
+|----------------|-------------------|
+| `Column gap="8"` per field | Label and input in a `Row` |
+| `fillWidth` on inputs | Fixed pixel widths |
+| `label-default-s` for labels | `body-default-m` for field labels |
+| `gap="16"` between fields | Inconsistent margins |
+
+## Accessible defaults
+
+- Always set `id` on inputs and match with label `htmlFor` when using separate `Text` labels
+- Use built-in `label` prop on form controls when the component supports it
+- Group related fields in a `Column`, not a flat list
+
+## Check yourself
+
+- [ ] Each field is a `Column gap="8"`
+- [ ] Fields separated by `gap="16"`
+- [ ] Section title uses `display-strong-xs`
+- [ ] Inputs have `fillWidth`
+
+## Related
+
+→ [Static panel](/static-panel.mdx)
+→ Form controls reference: [docs.once-ui.com](https://docs.once-ui.com/once-ui/form-controls/input)

--- a/content/once-ui-learn/patterns/hero-section.mdx
+++ b/content/once-ui-learn/patterns/hero-section.mdx
@@ -1,0 +1,95 @@
+<Feedback title="6 min · Pattern" description="Every marketing page starts with a hero: eyebrow, headline, description, and actions — optionally with a subtle ambient glow." variant="info" />
+
+## Anatomy
+
+A Once UI hero has four layers:
+
+1. **Optional ambient glow** — full-bleed `Background` outside `maxWidth`
+2. **Eyebrow** — `label-default-s` in brand color
+3. **Headline** — `display-strong-l` or `display-strong-xl`
+4. **Actions** — `Row` of buttons, stacking on mobile
+
+## Basic hero (no decoration)
+
+```text
+<Column fillWidth horizontal="center" paddingY="80">
+  <Column maxWidth="m" gap="24" horizontal="center">
+    <Text variant="label-default-s" onBackground="brand-medium" align="center">
+      EYEBROW
+    </Text>
+    <Heading variant="display-strong-l" align="center">
+      Build faster with Once UI
+    </Heading>
+    <Text variant="body-default-m" onBackground="neutral-weak" align="center">
+      A semantic design system for humans and agents.
+    </Text>
+    <Row gap="16" horizontal="center" s={{ direction: "column" }}>
+      <Button href="/start">Get started</Button>
+      <Button variant="secondary" href="/docs">Documentation</Button>
+    </Row>
+  </Column>
+</Column>
+```
+
+## Hero with glow (optional)
+
+Add one ambient layer on the **full-bleed wrapper**, not inside `maxWidth`:
+
+```text
+<Column fillWidth horizontal="center" paddingY="80">
+  <Background
+    position="absolute" top="0" left="0" fill pointerEvents="none"
+    gradient={{
+      display: true,
+      colorStart: "brand-alpha-medium",
+      colorEnd: "static-transparent",
+      x: 50, y: 0,
+      width: 150, height: 80,
+      opacity: 60,
+    }}
+    dots={{ display: true, color: "neutral-alpha-weak", size: "2", opacity: 40 }}
+  />
+  <Column zIndex={1} maxWidth="m" gap="24" horizontal="center">
+    {/* hero content */}
+  </Column>
+</Column>
+```
+
+## Typography hierarchy
+
+| Element | Variant |
+|---------|---------|
+| Eyebrow | `label-default-s` + `onBackground="brand-medium"` |
+| Headline | `display-strong-l` (or `xl` for landing pages) |
+| Description | `body-default-m` + `onBackground="neutral-weak"` |
+
+Never use `heading-*` for the main hero title.
+
+## Decoration budget
+
+- **One** ambient layer per hero section
+- Glow `width`: 100–200 (quarter-percent units; 400 = 100%)
+- Use `brand-alpha-medium` for glows — not `brand-background-weak`
+- Content always gets `zIndex={1}` above decoration
+
+## Write this / not this
+
+| ✅ Once UI way | ❌ Common mistake |
+|----------------|-------------------|
+| `display-strong-l` for headline | `heading-strong-xl` for hero |
+| Glow outside `maxWidth` column | Glow clipped inside narrow container |
+| `pointerEvents="none"` on Background | Clickable decoration blocking buttons |
+| One glow per hero | Multiple competing gradient layers |
+
+## Check yourself
+
+- [ ] Eyebrow uses `label-default-s`
+- [ ] Headline uses `display-strong-l` or larger
+- [ ] Buttons stack on mobile via `s={{ direction: "column" }}`
+- [ ] At most one ambient decoration layer
+
+## Related
+
+→ [Page skeleton](/page-skeleton.mdx)
+→ [Decoration layers](/decoration-layers.mdx)
+→ [Typography scale](/typography-scale.mdx)

--- a/content/once-ui-learn/patterns/highlighted-card.mdx
+++ b/content/once-ui-learn/patterns/highlighted-card.mdx
@@ -1,0 +1,96 @@
+<Feedback title="5 min · Pattern" description="Card is for interactive surfaces. Add a top glow and brand border to emphasize one item in a set — like a featured pricing tier." variant="info" />
+
+## When to use
+
+Use a **highlighted card** when one item in a set should stand out **and is interactive**:
+
+- "Most popular" pricing tier
+- Featured plan or product
+- Selectable option with `onClick`
+
+Static, non-clickable panels use the [static panel](/static-panel.mdx) recipe instead.
+
+## Basic interactive card
+
+```text
+<Card href="/pricing/pro" fillWidth padding="24" radius="l" background="surface" border="neutral-alpha-weak">
+  <Column gap="16" fillWidth>
+    <Heading variant="heading-strong-m">Pro</Heading>
+    <Text variant="display-strong-s" onBackground="neutral-strong">$29/mo</Text>
+    <Text variant="body-default-s" onBackground="neutral-weak">
+      For growing teams.
+    </Text>
+    <Button fillWidth>Get started</Button>
+  </Column>
+</Card>
+```
+
+`Card` requires `href` or `onClick` — that's what makes it a card, not a panel.
+
+## Highlighted variant
+
+Add a brand border and top glow for emphasis:
+
+```text
+<Card href="/pricing/pro" fillWidth padding="24" radius="l" background="surface" border="brand-alpha-medium" overflow="hidden">
+  <Background
+    position="absolute" top="0" left="0" fill pointerEvents="none"
+    gradient={{
+      display: true,
+      colorStart: "brand-alpha-medium",
+      colorEnd: "static-transparent",
+      x: 50, y: 0,
+      width: 200, height: 60,
+      opacity: 50,
+    }}
+  />
+  <Column zIndex={1} gap="20" fillWidth>
+    <Text variant="label-default-s" onBackground="brand-medium">MOST POPULAR</Text>
+    <Heading variant="heading-strong-m">Pro</Heading>
+    <Text variant="display-strong-s" onBackground="neutral-strong">$29/mo</Text>
+    <Button fillWidth>Get started</Button>
+  </Column>
+</Card>
+```
+
+## Pricing row
+
+Place cards side by side, highlighted in the center or end:
+
+```text
+<Row gap="24" vertical="stretch" s={{ direction: "column" }}>
+  <Card href="/basic" fill padding="24" radius="l" background="surface" border="neutral-alpha-weak">
+    {/* basic tier */}
+  </Card>
+  <Card href="/pro" fill padding="24" radius="l" background="surface" border="brand-alpha-medium" overflow="hidden">
+    {/* highlighted tier with glow */}
+  </Card>
+  <Card href="/enterprise" fill padding="24" radius="l" background="surface" border="neutral-alpha-weak">
+    {/* enterprise tier */}
+  </Card>
+</Row>
+```
+
+Use `vertical="stretch"` so all tiers match height.
+
+## Write this / not this
+
+| ✅ Once UI way | ❌ Common mistake |
+|----------------|-------------------|
+| `Card` with `href` or `onClick` | `Card` for static content |
+| `Column` + surface props for static boxes | `Card` without interaction |
+| Glow only on highlighted tier | Glow on every card in the set |
+| `overflow="hidden"` when using inner glow | Glow bleeding past radius |
+
+## Check yourself
+
+- [ ] Every `Card` has `href` or `onClick`
+- [ ] Static tiers use neutral border
+- [ ] Highlighted tier has brand border + top glow
+- [ ] Content inside glow has `zIndex={1}`
+
+## Related
+
+→ [Static panel](/static-panel.mdx)
+→ [Decoration layers](/decoration-layers.mdx)
+→ Task bundle: [tasks/pricing.json](https://docs.once-ui.com/ai/tasks/pricing.json)

--- a/content/once-ui-learn/patterns/page-skeleton.mdx
+++ b/content/once-ui-learn/patterns/page-skeleton.mdx
@@ -1,0 +1,89 @@
+<Feedback title="5 min · Intermediate · Patterns" description="The page skeleton is the single most reused pattern in Once UI — master it and every page type becomes a variation." variant="info" />
+
+## The pattern
+
+Every marketing page, docs page, dashboard, and settings screen starts here:
+
+```text
+<Column as="main" fillWidth horizontal="center">
+  <Column maxWidth="l" paddingY="80" gap="104" fillWidth>
+    {/* sections go here */}
+  </Column>
+</Column>
+```
+
+Three layers:
+
+1. **Page wrapper** — `Column as="main"` centers content horizontally
+2. **Content column** — `maxWidth="l"` constrains readable width
+3. **Sections** — direct children with `gap="104"` between them
+
+## Width tokens
+
+| maxWidth | Use for |
+|----------|---------|
+| `"s"` | Narrow forms, auth pages |
+| `"m"` | Blog posts, focused content |
+| `"l"` | Marketing pages, dashboards (default) |
+| `"xl"` | Wide data tables, galleries |
+
+## Section template
+
+Each section inside the content column:
+
+```text
+<Column gap="24" horizontal="center">
+  <Text variant="label-default-s" onBackground="brand-medium">
+    EYEBROW
+  </Text>
+  <Heading variant="display-strong-s" align="center">
+    Section title
+  </Heading>
+  <Text variant="body-default-m" onBackground="neutral-weak" align="center">
+    Section description
+  </Text>
+  {/* section content */}
+</Column>
+```
+
+For left-aligned sections, drop `horizontal="center"` and `align="center"`.
+
+## Decoration placement
+
+Ambient backgrounds (glows, dots, MatrixFx) go on a **full-bleed wrapper outside** `maxWidth`:
+
+```text
+<Column fillWidth horizontal="center" paddingY="80" overflow="hidden">
+  <Background
+    position="absolute" top="0" left="0" fill pointerEvents="none"
+    gradient={{ display: true, colorStart: "brand-alpha-medium", colorEnd: "static-transparent", x: 50, y: 0, width: 150, height: 80, opacity: 60 }}
+  />
+  <Column zIndex={1} maxWidth="l" gap="24" horizontal="center">
+    {/* hero content */}
+  </Column>
+</Column>
+```
+
+Content always gets `zIndex={1}`. Decoration always gets `pointerEvents="none"`.
+
+## When to vary
+
+| Page type | Variation |
+|-----------|-----------|
+| Auth | `maxWidth="s"`, single section, no `gap="104"` |
+| Blog post | `maxWidth="m"`, prose-focused |
+| Dashboard | `maxWidth="l"`, left-aligned sections, `SplitView` |
+| Chat | `SplitView` or full-height `Column fill` |
+
+## Check yourself
+
+- [ ] `Column as="main"` is the outermost layout element
+- [ ] Content constrained with `maxWidth`
+- [ ] Sections are direct children with `gap="104"`
+- [ ] Decoration outside the `maxWidth` column
+
+## Related
+
+→ [Your first page](/your-first-page.mdx)
+→ [Spacing & rhythm](/spacing-and-rhythm.mdx)
+→ Decoration recipes: [docs.once-ui.com/ai/recipes.md](https://docs.once-ui.com/ai/recipes.md)

--- a/content/once-ui-learn/patterns/responsive-stacking.mdx
+++ b/content/once-ui-learn/patterns/responsive-stacking.mdx
@@ -1,0 +1,98 @@
+<Feedback title="5 min · Pattern" description="Once UI handles responsive layout through breakpoint props on components — not CSS media queries." variant="info" />
+
+## Breakpoint keys
+
+Override layout at breakpoints using props on the same component:
+
+| Key | Typical viewport |
+|-----|------------------|
+| `xl` | Largest |
+| `l` | Desktop |
+| `m` | Tablet |
+| `s` | Mobile landscape |
+| `xs` | Mobile portrait |
+
+Larger breakpoint styles cascade down. Set the desktop layout as defaults, then override at `s` or `m`.
+
+## Stack on mobile
+
+The most common pattern — horizontal row that becomes vertical:
+
+```text
+<Row gap="24" s={{ direction: "column" }}>
+  <Column fill>Left content</Column>
+  <Column fill>Right content</Column>
+</Row>
+```
+
+Desktop: side by side. Mobile (`s`): stacked.
+
+## Responsive grid
+
+Reduce columns as viewport shrinks:
+
+```text
+<Grid columns="3" gap="24" m={{ columns: "2" }} s={{ columns: "1" }}>
+  <Column>...</Column>
+  <Column>...</Column>
+  <Column>...</Column>
+</Grid>
+```
+
+## Responsive spacing
+
+Tighten gaps on smaller screens:
+
+```text
+<Column gap="32" s={{ gap: "16" }}>
+  ...
+</Column>
+```
+
+## Responsive buttons
+
+Stack CTA buttons on mobile:
+
+```text
+<Row gap="16" horizontal="center" s={{ direction: "column" }}>
+  <Button href="/start">Get started</Button>
+  <Button variant="secondary" href="/docs">Learn more</Button>
+</Row>
+```
+
+## When layout needs a direction flip only
+
+If the only responsive change is direction, use `Row` with breakpoint override — no need for a separate layout component:
+
+```text
+<Row gap="16" vertical="center" s={{ direction: "column", horizontal: "start" }}>
+  <Icon name="check" />
+  <Text variant="body-default-s">Feature description</Text>
+</Row>
+```
+
+## Write this / not this
+
+| ✅ Once UI way | ❌ Common mistake |
+|----------------|-------------------|
+| `s={{ direction: "column" }}` | CSS `@media` queries |
+| `s={{ columns: "1" }}` on Grid | Separate mobile component |
+| `s={{ gap: "16" }}` | Inline `style` overrides |
+| Desktop layout as default props | Mobile-first with `xs` only |
+
+## Server vs client
+
+Breakpoint props require client-side class resolution. Once UI's `Row`, `Column`, and `Grid` handle this automatically — they switch to client rendering when breakpoint props are present.
+
+## Check yourself
+
+- [ ] No CSS media queries for layout
+- [ ] Desktop layout set as default props
+- [ ] Mobile overrides use `s` or `m` keys
+- [ ] Buttons and panels stack with `s={{ direction: "column" }}`
+
+## Related
+
+→ [Row, Column & Grid](/layout-row-column-grid.mdx)
+→ [Hero section](/hero-section.mdx)
+→ [Page skeleton](/page-skeleton.mdx)

--- a/content/once-ui-learn/patterns/static-panel.mdx
+++ b/content/once-ui-learn/patterns/static-panel.mdx
@@ -1,0 +1,86 @@
+<Feedback title="4 min · Pattern" description="The static panel recipe is the most reused surface pattern in Once UI — for stats, settings sections, feature boxes, and pricing tiers that aren't clickable." variant="info" />
+
+## When to use
+
+Use a **static panel** when content sits inside a bordered surface but **nothing is clickable**:
+
+- Feature comparison columns
+- Settings sections
+- Stats blocks
+- Non-interactive pricing tier boxes
+
+For clickable tiles, use `Card` with `href` or `onClick` instead — see [Highlighted card](/highlighted-card.mdx).
+
+## The recipe
+
+```text
+<Column
+  background="surface"
+  border="neutral-alpha-weak"
+  radius="l"
+  padding="24"
+  gap="16"
+  fill
+>
+  <Heading variant="heading-strong-m">Panel title</Heading>
+  <Text variant="body-default-s" onBackground="neutral-weak">
+    Supporting description.
+  </Text>
+</Column>
+```
+
+Five props define the look:
+
+| Prop | Value | Role |
+|------|-------|------|
+| `background` | `"surface"` | Elevated panel fill |
+| `border` | `"neutral-alpha-weak"` | Subtle edge |
+| `radius` | `"l"` | Rounded corners |
+| `padding` | `"24"` | Inner breathing room |
+| `gap` | `"16"` | Space between children |
+
+## Grid of panels
+
+Place multiple panels in a responsive row:
+
+```text
+<Row gap="24" s={{ direction: "column" }}>
+  <Column background="surface" border="neutral-alpha-weak" radius="l" padding="24" gap="16" fill>
+    ...
+  </Column>
+  <Column background="surface" border="neutral-alpha-weak" radius="l" padding="24" gap="16" fill>
+    ...
+  </Column>
+</Row>
+```
+
+Use `fill` on each panel so they share width equally in a row.
+
+## Write this / not this
+
+| ✅ Once UI way | ❌ Common mistake |
+|----------------|-------------------|
+| `Column` + surface props | `Card` without `href` or `onClick` |
+| `background="surface"` | Hex background color |
+| `border="neutral-alpha-weak"` | `border: 1px solid #eee` |
+| `gap="16"` inside panel | Random margin on each child |
+
+## Variations
+
+| Need | Adjust |
+|------|--------|
+| Tighter panel | `padding="16"`, `gap="12"` |
+| Stronger border | `border="neutral-medium"` |
+| No border | `border="transparent"` |
+| Full-width strip | Drop `radius`, use `paddingX="24" paddingY="32"` |
+
+## Check yourself
+
+- [ ] Panel is a `Column`, not a `Card`
+- [ ] All five surface props are set
+- [ ] Inner gap is `"16"` or `"24"`
+
+## Related
+
+→ [Color & surfaces](/color-and-surfaces.mdx)
+→ [Highlighted card](/highlighted-card.mdx)

--- a/content/once-ui-learn/start/install-and-config.mdx
+++ b/content/once-ui-learn/start/install-and-config.mdx
@@ -1,0 +1,49 @@
+<Feedback title="5 min · Beginner · Start" description="Install @once-ui-system/core, wrap your app in providers, and you're ready to build." variant="info" />
+
+## Install
+
+```bash
+npm install @once-ui-system/core
+```
+
+Once UI targets **Next.js App Router** (React 18+). The package includes components, SCSS tokens, contexts, and the AI harness under `@once-ui-system/core/ai/`.
+
+## Minimal setup
+
+Wrap your root layout with the theme and layout providers from the package:
+
+1. Import `@once-ui-system/core/styles` once in your root layout
+2. Wrap children with `ThemeProvider` and `LayoutProvider` from `@once-ui-system/core`
+
+Full setup code and provider options are in the [config guide](https://docs.once-ui.com/once-ui/config).
+
+## Config (optional)
+
+Most projects work with defaults. When you need customization:
+
+- **Theme** — color scheme, accent, border style, surface fill via provider props or data attributes on the html element
+- **Layout** — max content widths, breakpoint values via the layout provider
+
+## Dev workflow
+
+To iterate on the library while building an app:
+
+```bash
+# Terminal 1 — watch the core package
+pnpm --filter @once-ui-system/core dev
+
+# Terminal 2 — run your app
+cd apps/dev && pnpm dev
+```
+
+The `apps/dev` sandbox in the monorepo is a live component playground — useful for seeing variants before you write docs or lessons.
+
+## Check yourself
+
+- [ ] Global styles imported in root layout
+- [ ] Theme and layout providers wrapping children
+- [ ] No Tailwind or global CSS fighting Once UI tokens
+
+## Next step
+
+→ [Your first page](/your-first-page.mdx)

--- a/content/once-ui-learn/start/what-is-once-ui.mdx
+++ b/content/once-ui-learn/start/what-is-once-ui.mdx
@@ -1,0 +1,54 @@
+<Feedback title="5 min · Beginner · Start" description="Once UI turns layout and styling into semantic props — so you (and your AI agent) write less code that stays correct longer." variant="info" />
+
+## The idea
+
+Most design systems give you components and leave you to wrestle with CSS. Once UI goes further: **layout, color, spacing, and typography are all expressed as props on semantic components**.
+
+That means:
+
+- `<Column gap="16">` instead of flexbox boilerplate
+- `background="surface"` instead of hex colors
+- `textVariant="display-strong-l"` instead of font-size + weight classes
+
+The goal is **maintainability** — for humans reading the code six months later, and for agents generating it today.
+
+## Agent-first, human-friendly
+
+Once UI ships a **codegen harness** alongside the React library:
+
+| Artifact | Purpose |
+|----------|---------|
+| `rules.compact.md` | Do/don't tables for layout, surfaces, motion |
+| `catalog.json` | Pick components by purpose and tags |
+| `tasks/*.json` | Intent bundles (pricing page, chat UI, auth flow) |
+| `validate-ai-code` | Mechanical check for common mistakes |
+
+Humans learn the *why* here on Learn. Agents load the *how* from the harness. Both follow the same rules.
+
+## Three principles
+
+**1. Semantics over implementation**
+
+Use `Row` and `Column` — not `Flex direction="row"`. Use `Media` — not `<img>`. The component name tells you the intent.
+
+**2. Tokens over raw values**
+
+Spacing uses a fixed scale (`"8"`, `"16"`, `"24"`, `"104"`). Colors use schemes (`brand-medium`, `neutral-alpha-weak`). Never hex, never arbitrary pixels in props.
+
+**3. Composition over configuration**
+
+Pages are built by nesting `Column` → `Column maxWidth="l"` → sections. Decoration layers sit outside the content column. Patterns repeat — page skeleton, static panel, interactive card.
+
+## What you'll learn here
+
+| Section | Covers |
+|---------|--------|
+| **Start** | Install, first page |
+| **Foundations** | Layout, spacing, color, type |
+| **Patterns** | Reusable compositions |
+| **Tips** | Quick fixes for common mistakes |
+| **For agents** | Harness workflow and validation |
+
+## Next step
+
+→ [Install & config](/install-and-config.mdx)

--- a/content/once-ui-learn/start/your-first-page.mdx
+++ b/content/once-ui-learn/start/your-first-page.mdx
@@ -1,0 +1,95 @@
+<Feedback title="10 min · Beginner · Start" description="Every Once UI page follows the same skeleton: a centered main column, a max-width content area, and sections spaced with token gaps." variant="info" />
+
+## The page skeleton
+
+Copy this structure for any new page:
+
+```text
+import { Column, Row, Heading, Text, Button } from "@once-ui-system/core";
+
+export default function HomePage() {
+  return (
+    <Column as="main" fillWidth horizontal="center">
+      <Column maxWidth="l" paddingY="80" gap="104" fillWidth>
+        {/* Section 1 — Hero */}
+        <Column gap="24" horizontal="center">
+          <Heading variant="display-strong-l" align="center">
+            Welcome
+          </Heading>
+          <Text variant="body-default-m" onBackground="neutral-weak" align="center">
+            Your first Once UI page.
+          </Text>
+          <Row gap="16" s={{ direction: "column" }}>
+            <Button href="/start">Get started</Button>
+            <Button variant="secondary" href="/docs">Docs</Button>
+          </Row>
+        </Column>
+
+        {/* Section 2 — Features */}
+        <Column gap="24">
+          <Heading variant="display-strong-s">Features</Heading>
+          <Row gap="24" s={{ direction: "column" }}>
+            <Column
+              background="surface"
+              border="neutral-alpha-weak"
+              radius="l"
+              padding="24"
+              gap="16"
+              fill
+            >
+              <Heading variant="heading-strong-m">Semantic layout</Heading>
+              <Text variant="body-default-s" onBackground="neutral-weak">
+                Row, Column, Grid — props instead of CSS.
+              </Text>
+            </Column>
+            <Column
+              background="surface"
+              border="neutral-alpha-weak"
+              radius="l"
+              padding="24"
+              gap="16"
+              fill
+            >
+              <Heading variant="heading-strong-m">Design tokens</Heading>
+              <Text variant="body-default-s" onBackground="neutral-weak">
+                Spacing, color, and type from a single scale.
+              </Text>
+            </Column>
+          </Row>
+        </Column>
+      </Column>
+    </Column>
+  );
+}
+```
+
+## Anatomy
+
+| Layer | What it does |
+|-------|--------------|
+| `Column as="main"` | Page wrapper, centered horizontally |
+| `maxWidth="l"` | Content column — prevents edge-to-edge text |
+| `gap="104"` | Space **between** major sections |
+| `gap="24"` | Space **inside** a section |
+| Static panels | `Column` + `background="surface"` — not `Card` |
+
+## Write this / not this
+
+| ✅ Once UI way | ❌ Common mistake |
+|----------------|-------------------|
+| `Column as="main" fillWidth horizontal="center"` | `<div className="container mx-auto">` |
+| `gap="104"` between sections | `margin-bottom: 48px` |
+| `Column` + surface props for panels | `<Card>` for non-interactive boxes |
+| `Row s={{ direction: "column" }}` | CSS `@media` for stacking |
+
+## Check yourself
+
+- [ ] Main wrapper uses `Column as="main"`
+- [ ] Content constrained with `maxWidth="l"` (or `"m"` for narrower pages)
+- [ ] Section gap is `"104"`, inner gap is `"24"`–`"40"`
+- [ ] Static feature boxes use the surface recipe, not `Card`
+
+## Go deeper
+
+→ [Page skeleton pattern](/page-skeleton.mdx)
+→ [Layout: Row, Column & Grid](/layout-row-column-grid.mdx)

--- a/content/once-ui-learn/tips/column-not-flex.mdx
+++ b/content/once-ui-learn/tips/column-not-flex.mdx
@@ -1,0 +1,56 @@
+<Feedback title="2 min · Tip" description="Row and Column exist for a reason. Flex with direction is the #1 mistake in generated Once UI code." variant="warning" />
+
+## The tip
+
+**Write this:**
+
+```text
+<Column gap="16">
+  <Heading variant="display-strong-s">Title</Heading>
+  <Text variant="body-default-m" onBackground="neutral-weak">Body</Text>
+</Column>
+```
+
+**Not this:** a `Flex` with `direction="column"` — use `Column` instead.
+
+## Why
+
+`Row` and `Column` are **semantic layout primitives**. They tell the reader (human or agent) the intent immediately. `Flex direction="column"` is an implementation detail that:
+
+- Adds noise to every layout block
+- Fails `validate-ai-code` checks
+- Makes diffs harder to review
+
+`Flex` exists for one case: **when direction changes at breakpoints**.
+
+```text
+<Row gap="24" s={{ direction: "column" }}>
+  <Column fill>Left</Column>
+  <Column fill>Right</Column>
+</Row>
+```
+
+## Same rule for horizontal
+
+**Write this:**
+
+```text
+<Row gap="16" vertical="center">
+  <Icon name="check" />
+  <Text variant="body-default-s">Done</Text>
+</Row>
+```
+
+**Not this:** a `Flex` with `direction="row"` — use `Row` instead.
+
+## Agent note
+
+The harness encodes this in `rules.compact.md` and `catalog.json`:
+
+- `Column.preferOver`: `"Flex with direction=\"column\""`
+- `Flex.avoid`: `"Static row/column layouts — use Row or Column instead"`
+
+## Related
+
+→ [Layout: Row, Column & Grid](/layout-row-column-grid.mdx)
+→ [Harness overview](/harness-overview.mdx)

--- a/content/once-ui-learn/upload.mjs
+++ b/content/once-ui-learn/upload.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * Upload Once UI Learn content to Aveiro via API.
+ * Usage: DOPLER_API_TOKEN=av_live_... node content/once-ui-learn/upload.mjs
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const API_BASE = "https://api.aveiro.app/api/v1";
+const TOKEN = process.env.DOPLER_API_TOKEN;
+
+if (!TOKEN) {
+  console.error("DOPLER_API_TOKEN is required");
+  process.exit(1);
+}
+
+const manifest = JSON.parse(readFileSync(join(__dirname, "manifest.json"), "utf8"));
+const { siteId, pages, deletePageIds } = manifest;
+
+async function api(method, path, body) {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${TOKEN}`,
+      "Content-Type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const data = await res.json();
+  if (!res.ok) {
+    throw new Error(`${method} ${path} → ${res.status}: ${JSON.stringify(data)}`);
+  }
+  return data;
+}
+
+async function main() {
+  console.log(`Site: ${siteId}`);
+  console.log(`Pages to upload: ${pages.length}`);
+
+  for (const id of deletePageIds) {
+    console.log(`Deleting old page ${id}...`);
+    await api("DELETE", `/sites/${siteId}/pages/${id}`);
+  }
+
+  for (const page of pages) {
+    const content = readFileSync(join(__dirname, page.file), "utf8");
+    const payload = {
+      path: page.path,
+      title: page.title,
+      content,
+      metadata: {
+        title: page.title,
+        summary: page.summary,
+      },
+    };
+
+    if (page.contentId) {
+      console.log(`Updating ${page.path}...`);
+      const { path: _path, ...updatePayload } = payload;
+      await api("PATCH", `/sites/${siteId}/pages/${page.contentId}`, updatePayload);
+    } else {
+      console.log(`Creating ${page.path}...`);
+      const result = await api("POST", `/sites/${siteId}/pages`, payload);
+      console.log(`  → ${result.page.id}`);
+    }
+  }
+
+  console.log("Done. Review drafts in the Aveiro editor and publish when ready.");
+}
+
+main().catch((err) => {
+  console.error(err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Phase 1 lesson content for the **Once UI Learn** Aveiro site (`learn-once-ui`), plus a script to sync drafts via the Aveiro API.

This is the learning layer proposed earlier — concepts and patterns for humans and agents, distinct from the reference docs and the agent harness.

## What's included

**18 lesson pages** in `content/once-ui-learn/`:

| Track | Pages |
|-------|-------|
| Home | Once UI Learn (homepage with three tracks) |
| Start | What is Once UI?, Install & config, Your first page |
| Foundations | Semantics, Layout, Spacing, Color, Typography |
| Patterns | Page skeleton, Static panel, Hero section, Form layout, Decoration layers, Highlighted card, Responsive stacking |
| Tips | Column, not Flex |
| For agents | Harness overview |

Each page uses:
- `Feedback` callouts for time/level context
- Write this / not this tables
- Check yourself lists
- Cross-links to docs and harness artifacts

## Aveiro sync

- `manifest.json` — page metadata and content IDs
- `upload.mjs` — pushes drafts to the Once UI Learn site via `POST/PATCH /api/v1/sites/{siteId}/pages`

Drafts are already uploaded to Aveiro. Review and publish in the editor.

## Notes

- Aveiro API v1 does not support creating nested folders via API — pages use flat paths (`/layout-row-column-grid.mdx`). Organize into sidebar groups in the Aveiro editor after publishing.
- Code examples use `text` fences (not `tsx`) to pass Aveiro MDX validation.
- Old Aveiro API placeholder pages on the Learn site were removed during upload.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b067111f-ee20-4664-89e5-d82b1737f896"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b067111f-ee20-4664-89e5-d82b1737f896"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

