### PR TITLE
fix(server): block SSRF in OG fetch and proxy endpoints

### DIFF
--- a/apps/docs/src/app/api/og/fetch/route.ts
+++ b/apps/docs/src/app/api/og/fetch/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server';
 import { handleOGFetch } from '@once-ui-system/core/server';
 
-export const runtime = 'edge';
+export const runtime = 'nodejs';
 
 export async function GET(request: NextRequest) {
   return handleOGFetch(request, {

--- a/packages/core/src/__tests__/og-url-validation.test.ts
+++ b/packages/core/src/__tests__/og-url-validation.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  OGUrlValidationError,
+  fetchValidatedUrl,
+  validateOgUrl,
+} from '../server/og-url-validation';
+
+const resolve4 = vi.fn();
+const resolve6 = vi.fn();
+
+vi.mock('node:dns', () => ({
+  promises: {
+    resolve4,
+    resolve6,
+  },
+}));
+
+describe('validateOgUrl', () => {
+  beforeEach(() => {
+    resolve4.mockReset();
+    resolve6.mockReset();
+    resolve4.mockRejectedValue(new Error('ENOTFOUND'));
+    resolve6.mockRejectedValue(new Error('ENOTFOUND'));
+  });
+
+  it('allows public HTTPS URLs after DNS resolves to a public address', async () => {
+    resolve4.mockResolvedValue(['93.184.216.34']);
+
+    const url = await validateOgUrl('https://example.com/page');
+
+    expect(url.hostname).toBe('example.com');
+  });
+
+  it('rejects missing and malformed URLs', async () => {
+    await expect(validateOgUrl('not-a-url')).rejects.toBeInstanceOf(OGUrlValidationError);
+    await expect(validateOgUrl('http://example.com')).rejects.toBeInstanceOf(OGUrlValidationError);
+    await expect(validateOgUrl('file:///etc/passwd')).rejects.toBeInstanceOf(OGUrlValidationError);
+  });
+
+  it('rejects URLs with embedded credentials', async () => {
+    await expect(validateOgUrl('https://user:pass@example.com')).rejects.toBeInstanceOf(
+      OGUrlValidationError,
+    );
+  });
+
+  it('blocks private, loopback, and metadata IP literals', async () => {
+    const blockedUrls = [
+      'https://127.0.0.1/',
+      'https://10.0.0.1/',
+      'https://172.16.0.1/',
+      'https://192.168.1.1/',
+      'https://169.254.169.254/latest/meta-data/',
+      'https://[::1]/',
+      'https://[fc00::1]/',
+      'https://[fe80::1]/',
+    ];
+
+    for (const blockedUrl of blockedUrls) {
+      await expect(validateOgUrl(blockedUrl)).rejects.toBeInstanceOf(OGUrlValidationError);
+    }
+  });
+
+  it('blocks localhost and internal hostnames', async () => {
+    await expect(validateOgUrl('https://localhost/')).rejects.toBeInstanceOf(OGUrlValidationError);
+    await expect(validateOgUrl('https://app.localhost/')).rejects.toBeInstanceOf(OGUrlValidationError);
+    await expect(validateOgUrl('https://metadata.google.internal/')).rejects.toBeInstanceOf(
+      OGUrlValidationError,
+    );
+    await expect(validateOgUrl('https://service.internal/')).rejects.toBeInstanceOf(
+      OGUrlValidationError,
+    );
+  });
+
+  it('blocks hostnames that resolve to private addresses', async () => {
+    resolve4.mockResolvedValue(['10.0.0.5']);
+
+    await expect(validateOgUrl('https://public-looking.example/')).rejects.toBeInstanceOf(
+      OGUrlValidationError,
+    );
+  });
+
+  it('enforces optional domain allowlists', async () => {
+    resolve4.mockResolvedValue(['93.184.216.34']);
+
+    await expect(
+      validateOgUrl('https://example.com', { allowedDomains: ['allowed.test'] }),
+    ).rejects.toBeInstanceOf(OGUrlValidationError);
+
+    await expect(
+      validateOgUrl('https://cdn.allowed.test/image.png', { allowedDomains: ['allowed.test'] }),
+    ).resolves.toBeDefined();
+  });
+});
+
+describe('fetchValidatedUrl', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    resolve4.mockReset();
+    resolve6.mockReset();
+    resolve4.mockResolvedValue(['93.184.216.34']);
+    resolve6.mockRejectedValue(new Error('ENOTFOUND'));
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('re-validates redirect targets and blocks private redirect destinations', async () => {
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { Location: 'https://127.0.0.1/secret' },
+        }),
+      ) as typeof fetch;
+
+    await expect(fetchValidatedUrl('https://example.com/start')).rejects.toBeInstanceOf(
+      OGUrlValidationError,
+    );
+  });
+
+  it('follows safe redirects manually', async () => {
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { Location: '/final' },
+        }),
+      )
+      .mockResolvedValueOnce(new Response('ok', { status: 200 })) as typeof fetch;
+
+    const response = await fetchValidatedUrl('https://example.com/start');
+
+    expect(response.status).toBe(200);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    expect(globalThis.fetch).toHaveBeenNthCalledWith(
+      1,
+      'https://example.com/start',
+      expect.objectContaining({ redirect: 'manual' }),
+    );
+    expect(globalThis.fetch).toHaveBeenNthCalledWith(
+      2,
+      'https://example.com/final',
+      expect.objectContaining({ redirect: 'manual' }),
+    );
+  });
+});

--- a/packages/core/src/server/og-url-validation.ts
+++ b/packages/core/src/server/og-url-validation.ts
@@ -1,0 +1,310 @@
+export class OGUrlValidationError extends Error {
+  constructor(message = 'URL is not allowed') {
+    super(message);
+    this.name = 'OGUrlValidationError';
+  }
+}
+
+export interface OGUrlValidationOptions {
+  /** When set, only these domains (and their subdomains) are permitted. */
+  allowedDomains?: string[];
+}
+
+const BLOCKED_HOSTNAMES = new Set([
+  'localhost',
+  'metadata.google.internal',
+  'metadata.google',
+]);
+
+const BLOCKED_HOSTNAME_SUFFIXES = ['.localhost', '.local', '.internal'];
+
+interface IPv4Range {
+  network: number;
+  mask: number;
+}
+
+const BLOCKED_IPV4_RANGES: IPv4Range[] = [
+  { network: 0x00000000, mask: 0xff000000 }, // 0.0.0.0/8
+  { network: 0x0a000000, mask: 0xff000000 }, // 10.0.0.0/8
+  { network: 0x64400000, mask: 0xffc00000 }, // 100.64.0.0/10
+  { network: 0x7f000000, mask: 0xff000000 }, // 127.0.0.0/8
+  { network: 0xa9fe0000, mask: 0xffff0000 }, // 169.254.0.0/16
+  { network: 0xac100000, mask: 0xfff00000 }, // 172.16.0.0/12
+  { network: 0xc0000000, mask: 0xffffff00 }, // 192.0.0.0/24
+  { network: 0xc0000200, mask: 0xffffff00 }, // 192.0.2.0/24 (TEST-NET-1)
+  { network: 0xc0a80000, mask: 0xffff0000 }, // 192.168.0.0/16
+  { network: 0xc6120000, mask: 0xfffe0000 }, // 198.18.0.0/15
+  { network: 0xc6336400, mask: 0xffffff00 }, // 198.51.100.0/24 (TEST-NET-2)
+  { network: 0xcb007100, mask: 0xffffff00 }, // 203.0.113.0/24 (TEST-NET-3)
+  { network: 0xe0000000, mask: 0xf0000000 }, // 224.0.0.0/4 (multicast)
+  { network: 0xf0000000, mask: 0xf0000000 }, // 240.0.0.0/4 (reserved)
+];
+
+function ipv4ToInt(ip: string): number | null {
+  const parts = ip.split('.');
+  if (parts.length !== 4) {
+    return null;
+  }
+
+  let value = 0;
+  for (const part of parts) {
+    if (!/^\d+$/.test(part)) {
+      return null;
+    }
+    const octet = Number(part);
+    if (octet < 0 || octet > 255) {
+      return null;
+    }
+    value = (value << 8) + octet;
+  }
+
+  return value >>> 0;
+}
+
+function isBlockedIPv4(ip: string): boolean {
+  const value = ipv4ToInt(ip);
+  if (value === null) {
+    return true;
+  }
+
+  return BLOCKED_IPV4_RANGES.some(
+    (range) => (value & range.mask) === (range.network & range.mask),
+  );
+}
+
+function expandIPv6(ip: string): bigint | null {
+  const lower = ip.toLowerCase();
+
+  if (lower.includes('%')) {
+    return null;
+  }
+
+  const [head, tail = ''] = lower.split('::');
+  if (lower.split('::').length > 2) {
+    return null;
+  }
+
+  const headGroups = head ? head.split(':') : [];
+  const tailGroups = tail ? tail.split(':') : [];
+  const missingGroups = 8 - (headGroups.length + tailGroups.length);
+
+  if (missingGroups < 0) {
+    return null;
+  }
+
+  const groups = [
+    ...headGroups,
+    ...Array.from({ length: missingGroups }, () => '0'),
+    ...tailGroups,
+  ];
+
+  if (groups.length !== 8) {
+    return null;
+  }
+
+  let value = 0n;
+  for (const group of groups) {
+    if (!/^[0-9a-f]{1,4}$/.test(group)) {
+      return null;
+    }
+    value = (value << 16n) + BigInt(parseInt(group, 16));
+  }
+
+  return value;
+}
+
+function isBlockedIPv6(ip: string): boolean {
+  const normalized = ip.toLowerCase();
+
+  if (normalized === '::1') {
+    return true;
+  }
+
+  const value = expandIPv6(normalized);
+  if (value === null) {
+    return true;
+  }
+
+  // Unique local addresses (fc00::/7)
+  if ((value & 0xfe00_0000_0000_0000_0000_0000_0000_0000n) === 0xfc00_0000_0000_0000_0000_0000_0000_0000n) {
+    return true;
+  }
+
+  // Link-local addresses (fe80::/10)
+  if ((value & 0xffc0_0000_0000_0000_0000_0000_0000_0000n) === 0xfe80_0000_0000_0000_0000_0000_0000_0000n) {
+    return true;
+  }
+
+  // IPv4-mapped IPv6 addresses (::ffff:x.x.x.x)
+  if ((value & 0xffff_ffff_ffff_ffff_0000_0000_0000_0000n) === 0x0000_0000_0000_0000_0000_ffff_0000_0000n) {
+    const mappedIpv4 =
+      `${Number((value >> 24n) & 0xffn)}.` +
+      `${Number((value >> 16n) & 0xffn)}.` +
+      `${Number((value >> 8n) & 0xffn)}.` +
+      `${Number(value & 0xffn)}`;
+    return isBlockedIPv4(mappedIpv4);
+  }
+
+  return false;
+}
+
+function parseIpAddress(hostname: string): string | null {
+  let candidate = hostname;
+
+  if (candidate.startsWith('[') && candidate.endsWith(']')) {
+    candidate = candidate.slice(1, -1);
+  }
+
+  if (ipv4ToInt(candidate) !== null) {
+    return candidate;
+  }
+
+  if (expandIPv6(candidate) !== null) {
+    return candidate;
+  }
+
+  return null;
+}
+
+function isBlockedIpAddress(ip: string): boolean {
+  if (ip.includes(':')) {
+    return isBlockedIPv6(ip);
+  }
+
+  return isBlockedIPv4(ip);
+}
+
+function isBlockedHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().replace(/\.$/, '');
+
+  if (BLOCKED_HOSTNAMES.has(normalized)) {
+    return true;
+  }
+
+  if (BLOCKED_HOSTNAME_SUFFIXES.some((suffix) => normalized.endsWith(suffix))) {
+    return true;
+  }
+
+  const ipAddress = parseIpAddress(normalized);
+  return ipAddress ? isBlockedIpAddress(ipAddress) : false;
+}
+
+function isDomainAllowed(hostname: string, allowedDomains: string[]): boolean {
+  const normalized = hostname.toLowerCase().replace(/\.$/, '');
+
+  return allowedDomains.some((domain) => {
+    const allowed = domain.toLowerCase();
+    return normalized === allowed || normalized.endsWith(`.${allowed}`);
+  });
+}
+
+async function resolveHostnameAddresses(hostname: string): Promise<string[]> {
+  const dns = await import('node:dns');
+  const addresses = new Set<string>();
+
+  await Promise.all([
+    dns.promises.resolve4(hostname).then((ips) => {
+      for (const ip of ips) {
+        addresses.add(ip);
+      }
+    }).catch(() => undefined),
+    dns.promises.resolve6(hostname).then((ips) => {
+      for (const ip of ips) {
+        addresses.add(ip);
+      }
+    }).catch(() => undefined),
+  ]);
+
+  if (addresses.size === 0) {
+    throw new OGUrlValidationError('URL hostname could not be resolved');
+  }
+
+  return [...addresses];
+}
+
+function parsePublicUrl(urlString: string): URL {
+  let parsed: URL;
+
+  try {
+    parsed = new URL(urlString);
+  } catch {
+    throw new OGUrlValidationError('URL is malformed');
+  }
+
+  if (parsed.protocol !== 'https:') {
+    throw new OGUrlValidationError('Only HTTPS URLs are allowed');
+  }
+
+  if (parsed.username || parsed.password) {
+    throw new OGUrlValidationError('URL credentials are not allowed');
+  }
+
+  if (!parsed.hostname) {
+    throw new OGUrlValidationError('URL hostname is required');
+  }
+
+  return parsed;
+}
+
+export async function validateOgUrl(
+  urlString: string,
+  options: OGUrlValidationOptions = {},
+): Promise<URL> {
+  const parsed = parsePublicUrl(urlString);
+  const hostname = parsed.hostname.toLowerCase();
+
+  if (options.allowedDomains?.length) {
+    if (!isDomainAllowed(hostname, options.allowedDomains)) {
+      throw new OGUrlValidationError('URL domain is not allowed');
+    }
+  }
+
+  if (isBlockedHostname(hostname)) {
+    throw new OGUrlValidationError('URL hostname is not allowed');
+  }
+
+  const ipAddress = parseIpAddress(hostname);
+  if (!ipAddress) {
+    const resolvedAddresses = await resolveHostnameAddresses(hostname);
+    for (const address of resolvedAddresses) {
+      if (isBlockedIpAddress(address)) {
+        throw new OGUrlValidationError('URL resolves to a blocked address');
+      }
+    }
+  }
+
+  return parsed;
+}
+
+const MAX_REDIRECTS = 3;
+
+export async function fetchValidatedUrl(
+  urlString: string,
+  init: RequestInit = {},
+  validationOptions: OGUrlValidationOptions = {},
+): Promise<Response> {
+  let currentUrl = urlString;
+
+  for (let redirectCount = 0; redirectCount <= MAX_REDIRECTS; redirectCount++) {
+    await validateOgUrl(currentUrl, validationOptions);
+
+    const response = await fetch(currentUrl, {
+      ...init,
+      redirect: 'manual',
+    });
+
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get('location');
+      if (!location) {
+        throw new OGUrlValidationError('Redirect response missing location');
+      }
+
+      currentUrl = new URL(location, currentUrl).href;
+      continue;
+    }
+
+    return response;
+  }
+
+  throw new OGUrlValidationError('Too many redirects');
+}

--- a/packages/core/src/server/og-utils.ts
+++ b/packages/core/src/server/og-utils.ts
@@ -1,4 +1,10 @@
 import { NextResponse } from 'next/server';
+import {
+  fetchValidatedUrl,
+  OGUrlValidationError,
+  type OGUrlValidationOptions,
+  validateOgUrl,
+} from './og-url-validation';
 
 export interface OGData {
   url: string;
@@ -8,7 +14,7 @@ export interface OGData {
   faviconUrl?: string;
 }
 
-export interface OGFetchOptions {
+export interface OGFetchOptions extends OGUrlValidationOptions {
   timeout?: number;
   userAgent?: string;
   decodeEntities?: boolean;
@@ -39,17 +45,26 @@ function decodeHTMLEntities(text: string): string {
   });
 }
 
-async function fetchWithTimeout(url: string, timeout = 5000, userAgent = 'Mozilla/5.0 (compatible; OG-Fetcher/1.0)') {
+async function fetchWithTimeout(
+  url: string,
+  timeout = 5000,
+  userAgent = 'Mozilla/5.0 (compatible; OG-Fetcher/1.0)',
+  validationOptions: OGUrlValidationOptions = {},
+) {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeout);
 
   try {
-    const response = await fetch(url, { 
-      signal: controller.signal,
-      headers: {
-        'User-Agent': userAgent
-      }
-    });
+    const response = await fetchValidatedUrl(
+      url,
+      {
+        signal: controller.signal,
+        headers: {
+          'User-Agent': userAgent,
+        },
+      },
+      validationOptions,
+    );
     clearTimeout(timeoutId);
     return response;
   } catch (error) {
@@ -58,8 +73,17 @@ async function fetchWithTimeout(url: string, timeout = 5000, userAgent = 'Mozill
   }
 }
 
+function validationErrorResponse(): NextResponse {
+  return NextResponse.json({ error: 'URL is not allowed' }, { status: 400 });
+}
+
 export async function handleOGFetch(request: Request, options: OGFetchOptions = {}): Promise<NextResponse> {
-  const { timeout = 5000, userAgent = 'Mozilla/5.0 (compatible; OG-Fetcher/1.0)', decodeEntities = true } = options;
+  const {
+    timeout = 5000,
+    userAgent = 'Mozilla/5.0 (compatible; OG-Fetcher/1.0)',
+    decodeEntities = true,
+    allowedDomains,
+  } = options;
   const { searchParams } = new URL(request.url);
   const url = searchParams.get('url');
 
@@ -67,11 +91,22 @@ export async function handleOGFetch(request: Request, options: OGFetchOptions = 
     return NextResponse.json({ error: 'URL parameter is required' }, { status: 400 });
   }
 
+  const validationOptions = { allowedDomains };
+
   try {
-    const response = await fetchWithTimeout(url, timeout, userAgent);
+    await validateOgUrl(url, validationOptions);
+  } catch (error) {
+    if (error instanceof OGUrlValidationError) {
+      return validationErrorResponse();
+    }
+    return validationErrorResponse();
+  }
+
+  try {
+    const response = await fetchWithTimeout(url, timeout, userAgent, validationOptions);
 
     if (!response.ok) {
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      throw new Error(`HTTP ${response.status}`);
     }
 
     const html = await response.text();
@@ -120,19 +155,23 @@ export async function handleOGFetch(request: Request, options: OGFetchOptions = 
   } catch (error) {
     console.error('Error fetching OG data:', error);
     return NextResponse.json(
-      { error: 'Failed to fetch Open Graph data', message: error instanceof Error ? error.message : 'Unknown error' },
+      { error: 'Failed to fetch Open Graph data' },
       { status: 500 }
     );
   }
 }
 
-export interface OGProxyOptions {
+export interface OGProxyOptions extends OGUrlValidationOptions {
   userAgent?: string;
   cacheMaxAge?: number;
 }
 
 export async function handleOGProxy(request: Request, options: OGProxyOptions = {}): Promise<NextResponse> {
-  const { userAgent = 'Mozilla/5.0 (compatible; OG-Proxy/1.0)', cacheMaxAge = 3600 } = options;
+  const {
+    userAgent = 'Mozilla/5.0 (compatible; OG-Proxy/1.0)',
+    cacheMaxAge = 3600,
+    allowedDomains,
+  } = options;
   const { searchParams } = new URL(request.url);
   const url = searchParams.get('url');
 
@@ -140,17 +179,32 @@ export async function handleOGProxy(request: Request, options: OGProxyOptions = 
     return NextResponse.json({ error: 'URL parameter is required' }, { status: 400 });
   }
 
+  const validationOptions = { allowedDomains };
+
   try {
-    const response = await fetch(url, {
-      headers: {
-        'User-Agent': userAgent,
+    await validateOgUrl(url, validationOptions);
+  } catch (error) {
+    if (error instanceof OGUrlValidationError) {
+      return validationErrorResponse();
+    }
+    return validationErrorResponse();
+  }
+
+  try {
+    const response = await fetchValidatedUrl(
+      url,
+      {
+        headers: {
+          'User-Agent': userAgent,
+        },
       },
-    });
+      validationOptions,
+    );
 
     if (!response.ok) {
       return NextResponse.json(
-        { error: `Failed to fetch image: ${response.status}` },
-        { status: response.status }
+        { error: 'Failed to fetch image' },
+        { status: response.status >= 400 && response.status < 600 ? response.status : 502 }
       );
     }
 
@@ -166,8 +220,11 @@ export async function handleOGProxy(request: Request, options: OGProxyOptions = 
   } catch (error) {
     console.error('Error proxying image:', error);
     return NextResponse.json(
-      { error: 'Failed to proxy image', message: error instanceof Error ? error.message : 'Unknown error' },
+      { error: 'Failed to proxy image' },
       { status: 500 }
     );
   }
 }
+
+export { OGUrlValidationError, validateOgUrl } from './og-url-validation';
+export type { OGUrlValidationOptions } from './og-url-validation';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses a high-severity SSRF / open-proxy vulnerability in `handleOGFetch` and `handleOGProxy`, which previously accepted arbitrary `url` query parameters and performed unvalidated server-side HTTP requests.

## Changes

- Added `og-url-validation.ts` with centralized URL safety checks:
  - HTTPS-only scheme enforcement
  - Rejection of URLs with embedded credentials
  - Blocking of private, loopback, link-local, multicast, reserved, and cloud-metadata IP ranges (IPv4 and IPv6)
  - Blocking of `localhost`, `.local`, `.internal`, and metadata hostnames
  - DNS resolution with post-resolution IP range checks
  - Manual redirect handling with re-validation on each hop (max 3)
  - Optional `allowedDomains` allowlist support
- Updated `handleOGFetch` and `handleOGProxy` to validate URLs before fetching and to return generic client errors (no upstream/network error leakage)
- Switched `apps/docs` OG fetch route from Edge to Node.js runtime so DNS-based validation is available
- Added unit tests covering blocked schemes, private IPs, internal hostnames, DNS-to-private resolution, allowlists, and redirect re-validation

## Security impact

This closes the reported attack paths against:
- Cloud metadata services (e.g. `169.254.169.254`)
- Internal network scanning/access via private IPs
- Unauthenticated open-proxy usage via `/api/og/proxy`
- Error-message side channels revealing network topology

## Testing

- `pnpm --filter @once-ui-system/core test src/__tests__/og-url-validation.test.ts` (9/9 passing)
- `pnpm --filter @once-ui-system/core build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-489e32cb-635e-4891-b6b5-0aa6b21e8a61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-489e32cb-635e-4891-b6b5-0aa6b21e8a61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

