### PR TITLE
Add custom video controls to Media

### DIFF
--- a/apps/dev/src/components/ComponentsCheckPage.tsx
+++ b/apps/dev/src/components/ComponentsCheckPage.tsx
@@ -1134,6 +1134,21 @@ export default function ComponentsCheck() {
                 />
               ),
             },
+            {
+              value: "video",
+              label: "Video",
+              element: (
+                <Media
+                  src="https://www.w3schools.com/html/mov_bbb.mp4"
+                  aspectRatio="16/9"
+                  radius="l"
+                  controls
+                  sound
+                  autoplay={false}
+                  loop={false}
+                />
+              ),
+            },
           ],
         },
         {

--- a/apps/docs/src/content/once-ui/components/media.mdx
+++ b/apps/docs/src/content/once-ui/components/media.mdx
@@ -269,6 +269,43 @@ The component auto-detects and renders YouTube links, just pass a YouTube URL to
   ]}
 />
 
+## Video
+
+For MP4 and other file-based video, set `controls` to render a minimal custom player with play/pause, seek, mute, and fullscreen. Keyboard shortcuts: space (play/pause), `m` (mute), `f` (fullscreen), arrow keys (seek).
+
+<CodeBlock
+  marginTop="16"
+  marginBottom="24"
+  previewPadding="0"
+  preview={
+    <Media
+      src="https://www.w3schools.com/html/mov_bbb.mp4"
+      aspectRatio="16/9"
+      autoplay={false}
+      controls
+      sound
+      loop={false}
+      radius="xl"
+    />
+  }
+  codes={[
+    {
+      code:
+`<Media
+    src="/video.mp4"
+    aspectRatio="16/9"
+    autoplay={false}
+    controls
+    sound
+    loop={false}
+    radius="xl"
+/>`,
+      language: "tsx",
+      label: "Video"
+    }
+  ]}
+/>
+
 ## API reference
 
 <PropsTable

--- a/packages/core/ai/catalog.json
+++ b/packages/core/ai/catalog.json
@@ -1,6 +1,6 @@
 {
- "version": "1.7.11",
- "generated": "2026-07-05",
+ "version": "1.7.12",
+ "generated": "2026-07-21",
  "components": {
   "Accordion": {
    "group": "components",

--- a/packages/core/ai/manifest.json
+++ b/packages/core/ai/manifest.json
@@ -1,6 +1,6 @@
 {
- "version": "1.7.11",
- "generated": "2026-07-05",
+ "version": "1.7.12",
+ "generated": "2026-07-21",
  "files": {
   "spec": "spec.json",
   "catalog": "catalog.json",

--- a/packages/core/ai/spec.json
+++ b/packages/core/ai/spec.json
@@ -1,7 +1,7 @@
 {
  "name": "@once-ui-system/core",
- "version": "1.7.11",
- "generated": "2026-07-05",
+ "version": "1.7.12",
+ "generated": "2026-07-21",
  "format": "props are 'type', 'type = default', or '!type' (required). Components with 'mixins' also accept all props of those mixins. 'extends' means all props of that component are accepted.",
  "tokens": {
   "StaticSpacingToken": "\"0\" | \"1\" | \"2\" | \"4\" | \"8\" | \"12\" | \"16\" | \"20\" | \"24\" | \"32\" | \"40\" | \"48\" | \"56\" | \"64\" | \"80\" | \"104\" | \"128\" | \"160\"",
@@ -18,7 +18,7 @@
   "TextWeight": "\"default\" | \"strong\"",
   "TextSize": "TShirtSizes",
   "TextVariant": "`${TextType}-${TextWeight}-${TextSize}`",
-  "IconName": "\"chevronUp\" | \"chevronDown\" | \"chevronRight\" | \"chevronLeft\" | \"chevronsLeftRight\" | \"refresh\" | \"light\" | \"dark\" | \"help\" | \"info\" | \"warning\" | \"danger\" | \"checkbox\" | \"check\" | \"copy\" | \"eyeDropper\" | \"clipboard\" | \"person\" | \"close\" | \"link\" | \"arrowUpRight\" | \"minus\" | \"plus\" | \"calendar\" | \"eye\" | \"eyeOff\" | \"search\" | \"security\" | \"sparkle\" | \"computer\" | \"minimize\" | \"maximize\" | \"smiley\" | \"paw\" | \"food\" | \"ball\" | \"world\" | \"gift\" | \"symbol\" | \"flag\" | \"wordmark\" | \"enter\" | \"play\" | \"pause\" | \"screen\" | \"document\" | \"radialGauge\" | \"linearGauge\" | \"opacity\""
+  "IconName": "\"chevronUp\" | \"chevronDown\" | \"chevronRight\" | \"chevronLeft\" | \"chevronsLeftRight\" | \"refresh\" | \"light\" | \"dark\" | \"help\" | \"info\" | \"warning\" | \"danger\" | \"checkbox\" | \"check\" | \"copy\" | \"eyeDropper\" | \"clipboard\" | \"person\" | \"close\" | \"link\" | \"arrowUpRight\" | \"minus\" | \"plus\" | \"calendar\" | \"eye\" | \"eyeOff\" | \"search\" | \"security\" | \"sparkle\" | \"computer\" | \"minimize\" | \"maximize\" | \"smiley\" | \"paw\" | \"food\" | \"ball\" | \"world\" | \"gift\" | \"symbol\" | \"flag\" | \"wordmark\" | \"enter\" | \"play\" | \"pause\" | \"volume\" | \"volumeOff\" | \"screen\" | \"document\" | \"radialGauge\" | \"linearGauge\" | \"opacity\""
  },
  "mixins": {
   "CommonProps": {

--- a/packages/core/src/components/Media.tsx
+++ b/packages/core/src/components/Media.tsx
@@ -2,6 +2,7 @@
 
 import React, { CSSProperties, useState, useRef, useEffect, ReactNode } from "react";
 import { Column, Flex, Row, Skeleton, ScrollLock } from ".";
+import { MediaVideoPlayer } from "./MediaVideoPlayer";
 import Image from "next/image";
 import classNames from "classnames";
 
@@ -53,7 +54,7 @@ const Media: React.FC<MediaProps> = ({
   const imageRef = useRef<HTMLDivElement>(null);
 
   const handleImageClick = () => {
-    if (enlarge) {
+    if (canEnlarge) {
       if (!isEnlarged) {
         setIsEnlarged(true);
       } else {
@@ -140,6 +141,8 @@ const Media: React.FC<MediaProps> = ({
 
   const isVideo = isVideoUrl(src);
   const isYouTube = isYouTubeVideo(src);
+  const useCustomVideoControls = isVideo && controls;
+  const canEnlarge = enlarge && !useCustomVideoControls;
   const resolvedSizes =
     typeof sizes === "number"
       ? `(max-width: ${sizes}px) 100vw, ${sizes}px`
@@ -148,7 +151,7 @@ const Media: React.FC<MediaProps> = ({
   return (
     <>
       <ScrollLock enabled={isEnlarged} />
-      {isEnlarged && enlarge && typeof document !== 'undefined' && (
+      {isEnlarged && canEnlarge && typeof document !== 'undefined' && (
         <Flex
           center
           position="fixed"
@@ -187,11 +190,20 @@ const Media: React.FC<MediaProps> = ({
             ...style,
           }}
           onClick={handleImageClick}
-          className={classNames(enlarge && !isEnlarged ? "cursor-zoom-in" : enlarge && isEnlarged ? "cursor-zoom-out" : undefined, className)}
+          className={classNames(canEnlarge && !isEnlarged ? "cursor-zoom-in" : canEnlarge && isEnlarged ? "cursor-zoom-out" : undefined, className)}
           {...rest}
         >
           {loading && <Skeleton shape="block" radius={rest.radius} />}
-          {!loading && isVideo && (
+          {!loading && isVideo && useCustomVideoControls && (
+            <MediaVideoPlayer
+              src={src}
+              autoplay={autoplay}
+              loop={loop}
+              muted={!sound}
+              objectFit={objectFit}
+            />
+          )}
+          {!loading && isVideo && !useCustomVideoControls && (
             <video
               src={src}
               autoPlay={autoplay}

--- a/packages/core/src/components/MediaVideoPlayer.module.scss
+++ b/packages/core/src/components/MediaVideoPlayer.module.scss
@@ -1,0 +1,90 @@
+.container {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background: var(--neutral-solid-strong);
+  outline: none;
+
+  &:fullscreen,
+  &:-webkit-full-screen {
+    .video {
+      object-fit: contain;
+    }
+  }
+}
+
+.video {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  pointer-events: none;
+  transition: opacity var(--transition-micro-medium);
+
+  &.visible {
+    opacity: 1;
+  }
+
+  &.hidden {
+    opacity: 0;
+  }
+}
+
+.gradient {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to top,
+    rgba(0, 0, 0, 0.75) 0%,
+    rgba(0, 0, 0, 0.25) 35%,
+    transparent 65%
+  );
+  pointer-events: none;
+}
+
+.centerPlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: auto;
+}
+
+.centerPlayButton {
+  backdrop-filter: blur(0.5rem);
+  background: rgba(0, 0, 0, 0.45);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.controls {
+  position: relative;
+  z-index: 1;
+  pointer-events: auto;
+}
+
+.progressTrack {
+  height: 0.1875rem;
+  cursor: pointer;
+  transition: height var(--transition-micro-short);
+
+  &:hover {
+    height: 0.3125rem;
+  }
+}
+
+.progressFill {
+  transition: width 0.05s linear;
+}
+
+.time {
+  font-variant-numeric: tabular-nums;
+  user-select: none;
+}

--- a/packages/core/src/components/MediaVideoPlayer.tsx
+++ b/packages/core/src/components/MediaVideoPlayer.tsx
@@ -1,0 +1,427 @@
+"use client";
+
+import React, { CSSProperties, useCallback, useEffect, useRef, useState } from "react";
+import classNames from "classnames";
+import { Flex, IconButton, Row, Text } from ".";
+import styles from "./MediaVideoPlayer.module.scss";
+
+interface MediaVideoPlayerProps {
+  src: string;
+  autoplay?: boolean;
+  loop?: boolean;
+  muted?: boolean;
+  objectFit?: CSSProperties["objectFit"];
+  className?: string;
+}
+
+const formatTime = (seconds: number) => {
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return "0:00";
+  }
+
+  const totalSeconds = Math.floor(seconds);
+  const minutes = Math.floor(totalSeconds / 60);
+  const remainingSeconds = totalSeconds % 60;
+
+  return `${minutes}:${remainingSeconds.toString().padStart(2, "0")}`;
+};
+
+const MediaVideoPlayer: React.FC<MediaVideoPlayerProps> = ({
+  src,
+  autoplay = false,
+  loop = false,
+  muted: mutedProp = true,
+  objectFit = "cover",
+  className,
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const progressRef = useRef<HTMLDivElement>(null);
+  const hideControlsTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const isSeekingRef = useRef(false);
+
+  const [isPlaying, setIsPlaying] = useState(autoplay);
+  const [isMuted, setIsMuted] = useState(mutedProp);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const [controlsVisible, setControlsVisible] = useState(true);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [progress, setProgress] = useState(0);
+
+  const clearHideControlsTimeout = useCallback(() => {
+    if (hideControlsTimeoutRef.current) {
+      clearTimeout(hideControlsTimeoutRef.current);
+      hideControlsTimeoutRef.current = undefined;
+    }
+  }, []);
+
+  const scheduleHideControls = useCallback(() => {
+    clearHideControlsTimeout();
+
+    if (!videoRef.current || videoRef.current.paused) {
+      setControlsVisible(true);
+      return;
+    }
+
+    hideControlsTimeoutRef.current = setTimeout(() => {
+      setControlsVisible(false);
+    }, 2500);
+  }, [clearHideControlsTimeout]);
+
+  const revealControls = useCallback(() => {
+    setControlsVisible(true);
+    scheduleHideControls();
+  }, [scheduleHideControls]);
+
+  const syncPlaybackState = useCallback(() => {
+    const video = videoRef.current;
+    if (!video) {
+      return;
+    }
+
+    setIsPlaying(!video.paused);
+    setCurrentTime(video.currentTime);
+    setDuration(video.duration || 0);
+    setProgress(video.duration ? (video.currentTime / video.duration) * 100 : 0);
+  }, []);
+
+  const togglePlay = useCallback(async () => {
+    const video = videoRef.current;
+    if (!video) {
+      return;
+    }
+
+    if (video.paused) {
+      try {
+        await video.play();
+      } catch {
+        return;
+      }
+    } else {
+      video.pause();
+    }
+
+    syncPlaybackState();
+    revealControls();
+  }, [revealControls, syncPlaybackState]);
+
+  const toggleMute = useCallback(() => {
+    const video = videoRef.current;
+    if (!video) {
+      return;
+    }
+
+    video.muted = !video.muted;
+    setIsMuted(video.muted);
+    revealControls();
+  }, [revealControls]);
+
+  const toggleFullscreen = useCallback(async () => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+
+    try {
+      if (document.fullscreenElement) {
+        await document.exitFullscreen();
+      } else {
+        await container.requestFullscreen();
+      }
+    } catch {
+      return;
+    }
+
+    revealControls();
+  }, [revealControls]);
+
+  const seekToPosition = useCallback((clientX: number) => {
+    const video = videoRef.current;
+    const progressTrack = progressRef.current;
+    if (!video || !progressTrack || !video.duration) {
+      return;
+    }
+
+    const rect = progressTrack.getBoundingClientRect();
+    const ratio = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
+    video.currentTime = ratio * video.duration;
+    syncPlaybackState();
+  }, [syncPlaybackState]);
+
+  const handleProgressPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    event.stopPropagation();
+    isSeekingRef.current = true;
+    progressRef.current?.setPointerCapture(event.pointerId);
+    seekToPosition(event.clientX);
+    revealControls();
+  };
+
+  const handleProgressPointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!isSeekingRef.current) {
+      return;
+    }
+
+    seekToPosition(event.clientX);
+  };
+
+  const handleProgressPointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!isSeekingRef.current) {
+      return;
+    }
+
+    isSeekingRef.current = false;
+    progressRef.current?.releasePointerCapture(event.pointerId);
+    scheduleHideControls();
+  };
+
+  const handleContainerClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if ((event.target as HTMLElement).closest("[data-video-control]")) {
+      return;
+    }
+
+    togglePlay();
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    switch (event.key) {
+      case " ":
+      case "k":
+        event.preventDefault();
+        togglePlay();
+        break;
+      case "m":
+        event.preventDefault();
+        toggleMute();
+        break;
+      case "f":
+        event.preventDefault();
+        toggleFullscreen();
+        break;
+      case "ArrowLeft":
+        event.preventDefault();
+        if (videoRef.current) {
+          videoRef.current.currentTime = Math.max(0, videoRef.current.currentTime - 5);
+          syncPlaybackState();
+          revealControls();
+        }
+        break;
+      case "ArrowRight":
+        event.preventDefault();
+        if (videoRef.current) {
+          videoRef.current.currentTime = Math.min(
+            videoRef.current.duration || 0,
+            videoRef.current.currentTime + 5,
+          );
+          syncPlaybackState();
+          revealControls();
+        }
+        break;
+      default:
+        break;
+    }
+  };
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) {
+      return;
+    }
+
+    video.muted = mutedProp;
+
+    const handleLoadedMetadata = () => syncPlaybackState();
+    const handleTimeUpdate = () => syncPlaybackState();
+    const handlePlay = () => {
+      setIsPlaying(true);
+      scheduleHideControls();
+    };
+    const handlePause = () => {
+      setIsPlaying(false);
+      setControlsVisible(true);
+      clearHideControlsTimeout();
+    };
+    const handleVolumeChange = () => setIsMuted(video.muted);
+
+    video.addEventListener("loadedmetadata", handleLoadedMetadata);
+    video.addEventListener("timeupdate", handleTimeUpdate);
+    video.addEventListener("play", handlePlay);
+    video.addEventListener("pause", handlePause);
+    video.addEventListener("volumechange", handleVolumeChange);
+
+    if (autoplay) {
+      video.play().catch(() => {
+        setIsPlaying(false);
+        setControlsVisible(true);
+      });
+    }
+
+    return () => {
+      video.removeEventListener("loadedmetadata", handleLoadedMetadata);
+      video.removeEventListener("timeupdate", handleTimeUpdate);
+      video.removeEventListener("play", handlePlay);
+      video.removeEventListener("pause", handlePause);
+      video.removeEventListener("volumechange", handleVolumeChange);
+    };
+  }, [autoplay, clearHideControlsTimeout, mutedProp, scheduleHideControls, syncPlaybackState]);
+
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      setIsFullscreen(Boolean(document.fullscreenElement));
+    };
+
+    document.addEventListener("fullscreenchange", handleFullscreenChange);
+
+    return () => {
+      document.removeEventListener("fullscreenchange", handleFullscreenChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      clearHideControlsTimeout();
+    };
+  }, [clearHideControlsTimeout]);
+
+  const showCenterPlay = !isPlaying && controlsVisible;
+
+  return (
+    <div
+      ref={containerRef}
+      className={classNames(styles.container, className)}
+      tabIndex={0}
+      role="group"
+      aria-label="Video player"
+      onMouseMove={revealControls}
+      onTouchStart={revealControls}
+      onClick={handleContainerClick}
+      onKeyDown={handleKeyDown}
+    >
+      <video
+        ref={videoRef}
+        className={styles.video}
+        src={src}
+        loop={loop}
+        muted={isMuted}
+        playsInline
+        preload="metadata"
+        style={{ objectFit }}
+      />
+
+      <div
+        className={classNames(
+          styles.overlay,
+          controlsVisible || !isPlaying ? styles.visible : styles.hidden,
+        )}
+      >
+        <div className={styles.gradient} />
+
+        {showCenterPlay && (
+          <div className={styles.centerPlay} data-video-control>
+            <Flex
+              center
+              radius="full"
+              className={styles.centerPlayButton}
+              style={{ width: "4rem", height: "4rem" }}
+            >
+              <IconButton
+                variant="ghost"
+                icon="play"
+                tooltip="Play"
+                tooltipPosition="top"
+                onClick={(event: React.MouseEvent) => {
+                  event.stopPropagation();
+                  togglePlay();
+                }}
+                data-video-control
+              />
+            </Flex>
+          </div>
+        )}
+
+        <Flex
+          fillWidth
+          direction="column"
+          gap="8"
+          paddingX="12"
+          paddingBottom="12"
+          className={styles.controls}
+          data-video-control
+        >
+          <Row
+            ref={progressRef}
+            fillWidth
+            radius="full"
+            className={styles.progressTrack}
+            style={{ background: "rgba(255, 255, 255, 0.25)" }}
+            onPointerDown={handleProgressPointerDown}
+            onPointerMove={handleProgressPointerMove}
+            onPointerUp={handleProgressPointerUp}
+            onPointerCancel={handleProgressPointerUp}
+            role="slider"
+            aria-label="Seek"
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={Math.round(progress)}
+          >
+            <Row
+              radius="full"
+              fillHeight
+              className={styles.progressFill}
+              style={{ width: `${progress}%`, background: "var(--brand-solid-strong)" }}
+            />
+          </Row>
+
+          <Row fillWidth vertical="center" horizontal="between" gap="8">
+            <Row vertical="center" gap="4">
+              <IconButton
+                variant="ghost"
+                icon={isPlaying ? "pause" : "play"}
+                tooltip={isPlaying ? "Pause" : "Play"}
+                tooltipPosition="top"
+                onClick={(event: React.MouseEvent) => {
+                  event.stopPropagation();
+                  togglePlay();
+                }}
+              />
+
+              <Text
+                variant="label-default-xs"
+                onSolid="neutral-weak"
+                className={styles.time}
+              >
+                {formatTime(currentTime)} / {formatTime(duration)}
+              </Text>
+            </Row>
+
+            <Row vertical="center" gap="4">
+              <IconButton
+                variant="ghost"
+                icon={isMuted ? "volumeOff" : "volume"}
+                tooltip={isMuted ? "Unmute" : "Mute"}
+                tooltipPosition="top"
+                onClick={(event: React.MouseEvent) => {
+                  event.stopPropagation();
+                  toggleMute();
+                }}
+              />
+
+              <IconButton
+                variant="ghost"
+                icon={isFullscreen ? "minimize" : "maximize"}
+                tooltip={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
+                tooltipPosition="top"
+                onClick={(event: React.MouseEvent) => {
+                  event.stopPropagation();
+                  toggleFullscreen();
+                }}
+              />
+            </Row>
+          </Row>
+        </Flex>
+      </div>
+    </div>
+  );
+};
+
+MediaVideoPlayer.displayName = "MediaVideoPlayer";
+export { MediaVideoPlayer };

--- a/packages/core/src/icons.ts
+++ b/packages/core/src/icons.ts
@@ -36,6 +36,8 @@ import {
   HiOutlineArrowTurnDownLeft,
   HiOutlinePlay,
   HiOutlinePause,
+  HiOutlineSpeakerWave,
+  HiOutlineSpeakerXMark,
   HiOutlineBars3BottomLeft,
   HiOutlineAdjustmentsHorizontal,
 } from "react-icons/hi2";
@@ -97,6 +99,8 @@ export const iconLibrary: Record<string, IconType> = {
   enter: HiOutlineArrowTurnDownLeft,
   play: HiOutlinePlay,
   pause: HiOutlinePause,
+  volume: HiOutlineSpeakerWave,
+  volumeOff: HiOutlineSpeakerXMark,
   screen: HiOutlineComputerDesktop,
   document: HiOutlineBars3BottomLeft,
   radialGauge: PiGauge,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a minimal custom video player for native file-based video in `Media` when `controls` is enabled.

- New `MediaVideoPlayer` with play/pause, seek bar, elapsed/total time, mute toggle, and fullscreen
- Controls auto-hide while playing and reappear on hover, tap, or pause
- Keyboard shortcuts: space/k (play/pause), m (mute), f (fullscreen), arrow keys (seek ±5s)
- `enlarge` is disabled when custom controls are active to avoid click conflicts
- Added `volume` and `volumeOff` icons to the icon library
- Updated docs and dev sandbox with a working MP4 example

## Usage

```tsx
<Media
  src="/video.mp4"
  aspectRatio="16/9"
  autoplay={false}
  controls
  sound
  loop={false}
  radius="xl"
/>
```

## Test plan

- [x] Built `@once-ui-system/core` successfully
- [x] Verified in `apps/dev` Media → Video tab: playback, seek, mute, fullscreen, and keyboard shortcuts

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4aca1a0c-92da-4618-9c81-b6329bccca36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4aca1a0c-92da-4618-9c81-b6329bccca36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

