### PR TITLE
fix(security): prevent XSS in Schema JSON-LD and CodeBlock diff output

### DIFF
--- a/packages/core/src/__tests__/safe-html.test.ts
+++ b/packages/core/src/__tests__/safe-html.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { escapeHtml, safeScriptJson } from "../utils/safe-html";
+
+describe("safeScriptJson", () => {
+  it("escapes closing script tags in string values", () => {
+    const payload = { title: "</script><script>alert(1)</script>" };
+    const serialized = safeScriptJson(payload);
+
+    expect(serialized).not.toContain("</script>");
+    expect(serialized).toContain("\\u003c/script>");
+    expect(JSON.parse(serialized.replace(/\\u003c/g, "<"))).toEqual(payload);
+  });
+
+  it("escapes less-than in nested schema author fields", () => {
+    const schema = {
+      "@context": "https://schema.org",
+      author: { name: "<img src=x onerror=alert(1)>" },
+    };
+
+    const serialized = safeScriptJson(schema);
+
+    expect(serialized).not.toContain("<img");
+    expect(serialized).toContain("\\u003cimg");
+  });
+});
+
+describe("escapeHtml", () => {
+  it("escapes HTML metacharacters", () => {
+    expect(escapeHtml(`<script>alert("x")</script>`)).toBe(
+      "&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;",
+    );
+  });
+
+  it("escapes ampersands first", () => {
+    expect(escapeHtml("a & b < c")).toBe("a &amp; b &lt; c");
+  });
+});

--- a/packages/core/src/components/ThemeInit.tsx
+++ b/packages/core/src/components/ThemeInit.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { safeScriptJson } from '../utils/safe-html';
 
 interface ThemeConfig {
   theme: string;
@@ -27,7 +28,7 @@ export const ThemeInit: React.FC<ThemeInitProps> = ({ config }) => {
           (function() {
             try {
               const root = document.documentElement;
-              const config = ${JSON.stringify(config)};
+              const config = ${safeScriptJson(config)};
 
               // Apply config defaults FIRST (prevents FOUC)
               Object.entries(config).forEach(([key, value]) => {

--- a/packages/core/src/modules/code/CodeBlock.impl.tsx
+++ b/packages/core/src/modules/code/CodeBlock.impl.tsx
@@ -24,6 +24,7 @@ import {
   Button,
   Fade,
 } from "../../components";
+import { escapeHtml } from "../../utils/safe-html";
 
 let Prism: any;
 
@@ -352,18 +353,18 @@ const renderDiff = (
           if (prism.languages[lang]) {
             return prism.highlight(line.content, prism.languages[lang], lang);
           }
-          return line.content;
+          return escapeHtml(line.content);
         } catch (error) {
           console.warn(`Failed to highlight line: ${line.content}`, error);
-          return line.content;
+          return escapeHtml(line.content);
         }
       });
     } catch (error) {
       console.warn(`Failed to highlight code with language ${lang}:`, error);
-      highlightedLines = codeLines.map((line) => line.content);
+      highlightedLines = codeLines.map((line) => escapeHtml(line.content));
     }
   } else {
-    highlightedLines = codeLines.map((line) => line.content);
+    highlightedLines = codeLines.map((line) => escapeHtml(line.content));
   }
 
   let codeLineIndex = 0;
@@ -387,11 +388,14 @@ const renderDiff = (
                 `Failed to highlight diff line: ${line.content}`,
                 error,
               );
+              content = escapeHtml(line.content);
             }
+          } else {
+            content = escapeHtml(line.content);
           }
           className = "language-diff";
         } else {
-          content = highlightedLines[codeLineIndex] || line.content;
+          content = highlightedLines[codeLineIndex] || escapeHtml(line.content);
           className = `language-${lang || "diff"}`;
           codeLineIndex++;
         }
@@ -605,6 +609,7 @@ const CodeBlock: React.FC<CodeBlockProps> = ({
                   );
                 } catch (error) {
                   console.warn("Failed to re-highlight line:", error);
+                  codeContent.textContent = textContent;
                 }
               }
             });

--- a/packages/core/src/modules/seo/Schema.tsx
+++ b/packages/core/src/modules/seo/Schema.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Script from "next/script";
+import { safeScriptJson } from "../../utils/safe-html";
 
 export interface SchemaProps {
   as: "website" | "article" | "blogPosting" | "techArticle" | "webPage" | "organization";
@@ -96,9 +97,8 @@ export function Schema({
     <Script
       id={`schema-${as}-${path}`}
       type="application/ld+json"
-      // biome-ignore lint/security/noDangerouslySetInnerHtml: <It's not dynamic nor a security issue.>
       dangerouslySetInnerHTML={{
-        __html: JSON.stringify(schema),
+        __html: safeScriptJson(schema),
       }}
     />
   );

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./devLogger";
 export * from "./MissingDependency";
 export * from "./dropdownState";
+export * from "./safe-html";

--- a/packages/core/src/utils/safe-html.ts
+++ b/packages/core/src/utils/safe-html.ts
@@ -1,0 +1,21 @@
+/**
+ * Escapes HTML special characters for safe insertion into HTML text nodes
+ * or attributes when content is not already sanitized HTML.
+ */
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Serializes a value for safe embedding inside HTML <script> tags.
+ * JSON.stringify escapes quotes and backslashes but not `<`, which allows
+ * `</script>` breakout when prop values are attacker-controlled.
+ */
+export function safeScriptJson(value: unknown): string {
+  return JSON.stringify(value).replace(/</g, "\\u003c");
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two reported XSS vectors and hardens a related third case discovered during audit.

### Fixed

1. **`Schema` JSON-LD script breakout** — `JSON.stringify()` output is now passed through `safeScriptJson()`, which escapes `<` as `\u003c` to prevent `</script>` termination when prop values (title, description, author.name, etc.) are attacker-controlled.

2. **`CodeBlock` diff renderer** — When Prism highlighting is unavailable or fails, diff line content is now HTML-entity encoded via `escapeHtml()` before being passed to `dangerouslySetInnerHTML`. Re-highlight failures fall back to `textContent`.

3. **`ThemeInit` (discovered in audit)** — Same `<script>` JSON breakout pattern as `Schema`; now uses `safeScriptJson()`.

### New utilities

- `safeScriptJson()` — safe serialization for `<script>` tag embedding
- `escapeHtml()` — HTML entity encoding for untrusted text rendered as HTML

### Additional audit notes (not fixed in this PR)

| Area | Risk | Notes |
|------|------|-------|
| `SmartLink` / `Button` / `Card` `href` props | Medium (consumer-dependent) | No blocking of `javascript:` URLs; harden if hrefs can be user-controlled |
| `BlobFx` inline `<style>` | Low | Uses numeric `seed` only in generated CSS |
| `OgCard` fetched metadata | Low | Title/description render through React `Text`; images/URLs already SSRF-validated separately (#102) |
| Non-diff `CodeBlock` mode | Low | Uses `textContent` + `Prism.highlightElement` (safe path) |

Recommend follow-up PR to add `javascript:` / `data:` href sanitization for link components if untrusted URLs are expected.

### Test plan

- [x] `pnpm --filter @once-ui-system/core build`
- [x] New unit tests for `safeScriptJson` and `escapeHtml`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4aca1a0c-92da-4618-9c81-b6329bccca36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4aca1a0c-92da-4618-9c81-b6329bccca36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

