### PR TITLE
fix(code): resolve Prism grammars for md, mdx, dockerfile and shell aliases

### DIFF
--- a/packages/core/src/modules/code/CodeBlock.impl.tsx
+++ b/packages/core/src/modules/code/CodeBlock.impl.tsx
@@ -180,19 +180,52 @@ const loadedLanguages = new Set<string>([
   "javascript",
 ]);
 
+// Language names that intentionally have no grammar — render as plain text
+// without attempting (and warn-failing) a Prism component import.
+const PLAIN_TEXT_LANGUAGES = new Set(["text", "plain", "plaintext", "none"]);
+
+// Short names surfaced by editors → Prism component file names. Prism ships
+// `prism-typescript`, `prism-markdown`, `prism-docker`, …; importing
+// `prism-md` or `prism-dockerfile` throws and the code silently renders
+// unhighlighted. `mdx` has no Prism grammar of its own — TSX is the closest.
+const languageAliases: Record<string, string> = {
+  ts: "typescript",
+  js: "javascript",
+  html: "markup",
+  xml: "markup",
+  svg: "markup",
+  md: "markdown",
+  mdx: "tsx",
+  dockerfile: "docker",
+  sh: "bash",
+  shell: "bash",
+  zsh: "bash",
+  yml: "yaml",
+};
+
+// Make the requested name resolvable at highlight time. Most Prism components
+// self-register their aliases (`markdown` registers `md`, `docker` registers
+// `dockerfile`), but names Prism doesn't know (`mdx`) only highlight if we
+// point them at the canonical grammar ourselves.
+const registerLanguageAlias = async (lang: string, actualLang: string) => {
+  if (lang === actualLang) return;
+  const prism = await getPrism();
+  if (!prism.languages[lang] && prism.languages[actualLang]) {
+    prism.languages[lang] = prism.languages[actualLang];
+  }
+};
+
 // Recursively load language dependencies
 const loadLanguageWithDependencies = async (lang: string): Promise<boolean> => {
   if (typeof window === "undefined") return false;
 
-  // Handle language aliases
-  const languageAliases: Record<string, string> = {
-    ts: "typescript",
-  };
+  if (PLAIN_TEXT_LANGUAGES.has(lang)) return true;
 
   const actualLang = languageAliases[lang] || lang;
 
   // Skip if already loaded
   if (loadedLanguages.has(actualLang)) {
+    await registerLanguageAlias(lang, actualLang);
     return true;
   }
 
@@ -212,6 +245,7 @@ const loadLanguageWithDependencies = async (lang: string): Promise<boolean> => {
     await import(`prismjs/components/prism-${actualLang}`);
     loadedLanguages.add(actualLang);
     loadedLanguages.add(lang); // Also mark the alias as loaded
+    await registerLanguageAlias(lang, actualLang);
     return true;
   } catch (error) {
     console.warn(`✗ Failed to load Prism language '${lang}':`, error);


### PR DESCRIPTION
## Summary

`CodeBlock` loads grammars via `import("prismjs/components/prism-${lang}")` with only a `ts → typescript` alias. Prism names component files after the canonical grammar, so common short names silently fail to load — `prism-md`, `prism-mdx`, and `prism-dockerfile` don't exist — and those snippets render unhighlighted with nothing but a console.warn. (`js` and `html` only worked by accident, via aliases Prism's core bundle happens to register.)

## Changes (all in `packages/core/src/modules/code/CodeBlock.impl.tsx`)

- **Alias map extended** to real Prism component names: `md→markdown`, `dockerfile→docker`, `mdx→tsx` (closest grammar — Prism has no MDX), `html/xml/svg→markup`, `js→javascript`, `sh/shell/zsh→bash`, `yml→yaml`.
- **Requested-name registration**: after a component loads, the requested name is registered on the Prism instance when the component doesn't self-register it (`markdown` registers `md`, `docker` registers `dockerfile`, but nothing registers `mdx`) — so the `language-<lang>` class resolves at `highlightElement` time.
- **Plain-text languages** (`text`, `plain`, `plaintext`, `none`) are treated as intentional no-grammar values instead of warn-failing an import.

## Verification

- `pnpm --filter @once-ui-system/core build` — clean (tsc + sass).
- Node test against real `prismjs@1.30` mirroring the loader: all 29 language names offered by consuming editors (Magic/Aveiro's fenced-code dropdown ∪ its CodeBlock schema) load and resolve a grammar, with token-output spot-checks for `md`, `mdx`, and `dockerfile` — the three that previously produced plain text.

## Context

Companion to once-ui-system/magic#155, which fixes the platform side (CodeBlock missing from the AI component catalog, validator rejecting code fences). Once this ships in a release, Magic can add `mdx`/`dockerfile` to its CodeBlock schema and `md` starts highlighting there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UeqHkbaCzi4dKpnKWmX4r4

---
_Generated by [Claude Code](https://claude.ai/code/session_01UeqHkbaCzi4dKpnKWmX4r4)_