### PR TITLE
fix: DropdownWrapper misaligned for bottom-start/top-start since 1.8.0 (forced 320px min-width)

### DIFF
--- a/packages/core/src/components/DropdownWrapper.tsx
+++ b/packages/core/src/components/DropdownWrapper.tsx
@@ -163,10 +163,9 @@ const DropdownWrapper = forwardRef<HTMLDivElement, DropdownWrapperProps>(
               floatingStyle.width = w;
               floatingStyle.minWidth = minWidth ? `${minWidth}rem` : w;
             } else {
-              // Let content determine width; only enforce bounds
+              // Let content determine width; only apply an explicit minWidth
               floatingStyle.width = "";
-              const defaultMin = Math.min(320, availableWidth);
-              floatingStyle.minWidth = minWidth ? `${minWidth}rem` : `${defaultMin}px`;
+              floatingStyle.minWidth = minWidth ? `${minWidth}rem` : "";
             }
 
             floatingStyle.maxWidth = maxWidth ? `${maxWidth}rem` : `${availableWidth}px`;


### PR DESCRIPTION
## Problem

Since the 1.8.0 release (commit `6818bbb`, "Dropdown overflow/positioning"), `DropdownWrapper` breaks placement for `bottom-start` / `top-start` positions.

The positioning rework in that commit gave non-`fillWidth` dropdowns a **default `minWidth` of `min(320px, availableWidth)`** inside the floating-ui `size` middleware. Before 1.8.0, content-sized dropdowns had `width: auto` and no min-width unless the `minWidth` prop was set.

Consequences:
- Any content-sized menu (icon menus, small selects, context menus) inflates to up to 320px wide.
- When the trigger sits within 320px of the viewport edge, `shift()` pushes the widened dropdown sideways, so it no longer aligns with the trigger's start edge — visually breaking `bottom-start` and `top-start` placements.

## Fix

Restore the pre-1.8.0 sizing behavior for non-`fillWidth` dropdowns: content determines the width, and `minWidth` is only applied when the prop is explicitly set. The `fillWidth` branch and the `maxWidth` / `maxHeight` viewport bounds from the 1.8.0 rework are unchanged, as is the always-on `flip()`.

```diff
 } else {
-  // Let content determine width; only enforce bounds
+  // Let content determine width; only apply an explicit minWidth
   floatingStyle.width = "";
-  const defaultMin = Math.min(320, availableWidth);
-  floatingStyle.minWidth = minWidth ? `${minWidth}rem` : `${defaultMin}px`;
+  floatingStyle.minWidth = minWidth ? `${minWidth}rem` : "";
 }
```

Clearing to `""` (rather than leaving the old value) matters because the same floating element's inline style persists across middleware re-runs.

## Testing

- Verified the diff against the pre-1.8.0 middleware (`6dda4ff`) — behavior for content-sized dropdowns now matches 1.7.13 while keeping the other 1.8.0 positioning fixes.
- `tsc` in this environment reports only pre-existing module-resolution noise (dependencies not installed); the change itself introduces no new type surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMkP3hrsxShDCvh6FLCp6V)_