### PR TITLE
fix(docs): repair broken props tables and left-align OG image content

### DIFF
--- a/apps/docs/src/app/api/og/generate/route.tsx
+++ b/apps/docs/src/app/api/og/generate/route.tsx
@@ -30,7 +30,7 @@ export async function GET(request: Request) {
         padding: "8rem",
         background: "#0A0A0A",
         position: "relative",
-        alignItems: "center",
+        alignItems: "flex-start",
         justifyContent: "center",
         flexDirection: "column",
       }}
@@ -71,20 +71,20 @@ export async function GET(request: Request) {
         background: "#333333" 
       }} />
 
-      <img alt="trademark" src="https://docs.once-ui.com/trademarks/icon-dark.svg" width="200" height="200" />
+      <img alt="trademark" src="https://docs.once-ui.com/trademarks/icon-dark.svg" width={200} height={200} />
 
       <div
         style={{
           display: "flex",
           marginTop: "6rem",
           flexDirection: "column",
-          gap: "4rem",
+          gap: "2rem",
           fontFamily: "Geist",
           fontStyle: "normal",
           color: "white",
           width: "100%",
-          alignItems: "center",
-          textAlign: "center",
+          alignItems: "flex-start",
+          textAlign: "left",
         }}
       >
         <span
@@ -94,8 +94,7 @@ export async function GET(request: Request) {
             fontWeight: "bold",
             letterSpacing: "-0.05em",
             whiteSpace: "pre-wrap",
-            textWrap: "balance",
-            textAlign: "center",
+            textAlign: "left",
           }}
         >
           {title}
@@ -103,35 +102,17 @@ export async function GET(request: Request) {
         {description && (
           <span
             style={{
-              fontSize: "3rem",
-              lineHeight: "3.5rem",
+              fontSize: "2.5rem",
+              lineHeight: "3rem",
               color: "#9ca3af",
               fontWeight: "normal",
               whiteSpace: "pre-wrap",
-              textWrap: "balance",
-              marginTop: "-2rem",
-              textAlign: "center",
+              textAlign: "left",
             }}
           >
             {description}
           </span>
         )}
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: "5rem",
-          }}
-        >
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              gap: "0.75rem",
-            }}
-          >
-          </div>
-        </div>
       </div>
     </div>,
     {

--- a/apps/docs/src/content/once-ui/basics/spacing.mdx
+++ b/apps/docs/src/content/once-ui/basics/spacing.mdx
@@ -260,35 +260,35 @@ You can set the static and responsive spacing tokens for different margin proper
       [".mx-s", <InlineCode>var(--responsive-space-s)</InlineCode>, <InlineCode>40 / 24 / 16</InlineCode>],
       [".mx-m", <InlineCode>var(--responsive-space-m)</InlineCode>, <InlineCode>24 / 16 / 12</InlineCode>],
       [".mx-l", <InlineCode>var(--responsive-space-l)</InlineCode>, <InlineCode>16 / 12 / 8</InlineCode>],
-      [".mx-xl", <InlineCode>var(--responsive-space-xl)</InlineCode>, <InlineCode>12 / 8 / 4</InlineCode>]
+      [".mx-xl", <InlineCode>var(--responsive-space-xl)</InlineCode>, <InlineCode>12 / 8 / 4</InlineCode>],
 
       [<><InlineCode>margin-top</InlineCode> + <InlineCode>margin-bottom</InlineCode></>, "", ""],
       [".my-xs", <InlineCode>var(--responsive-space-xs)</InlineCode>, <InlineCode>80 / 64 / 40</InlineCode>],
       [".my-s", <InlineCode>var(--responsive-space-s)</InlineCode>, <InlineCode>40 / 24 / 16</InlineCode>],
       [".my-m", <InlineCode>var(--responsive-space-m)</InlineCode>, <InlineCode>24 / 16 / 12</InlineCode>],
       [".my-l", <InlineCode>var(--responsive-space-l)</InlineCode>, <InlineCode>16 / 12 / 8</InlineCode>],
-      [".my-xl", <InlineCode>var(--responsive-space-xl)</InlineCode>, <InlineCode>12 / 8 / 4</InlineCode>]
+      [".my-xl", <InlineCode>var(--responsive-space-xl)</InlineCode>, <InlineCode>12 / 8 / 4</InlineCode>],
 
       [<InlineCode>margin-top</InlineCode>, "", ""],
       [".mt-xs", <InlineCode>var(--responsive-space-xs)</InlineCode>, <InlineCode>80 / 64 / 40</InlineCode>],
       [".mt-s", <InlineCode>var(--responsive-space-s)</InlineCode>, <InlineCode>40 / 24 / 16</InlineCode>],
       [".mt-m", <InlineCode>var(--responsive-space-m)</InlineCode>, <InlineCode>24 / 16 / 12</InlineCode>],
       [".mt-l", <InlineCode>var(--responsive-space-l)</InlineCode>, <InlineCode>16 / 12 / 8</InlineCode>],
-      [".mt-xl", <InlineCode>var(--responsive-space-xl)</InlineCode>, <InlineCode>12 / 8 / 4</InlineCode>]
+      [".mt-xl", <InlineCode>var(--responsive-space-xl)</InlineCode>, <InlineCode>12 / 8 / 4</InlineCode>],
 
       [<InlineCode>margin-right</InlineCode>, "", ""],
       [".mr-xs", <InlineCode>var(--responsive-space-xs)</InlineCode>, <InlineCode>80 / 64 / 40</InlineCode>],
       [".mr-s", <InlineCode>var(--responsive-space-s)</InlineCode>, <InlineCode>40 / 24 / 16</InlineCode>],
       [".mr-m", <InlineCode>var(--responsive-space-m)</InlineCode>, <InlineCode>24 / 16 / 12</InlineCode>],
       [".mr-l", <InlineCode>var(--responsive-space-l)</InlineCode>, <InlineCode>16 / 12 / 8</InlineCode>],
-      [".mr-xl", <InlineCode>var(--responsive-space-xl)</InlineCode>, <InlineCode>12 / 8 / 4</InlineCode>]
+      [".mr-xl", <InlineCode>var(--responsive-space-xl)</InlineCode>, <InlineCode>12 / 8 / 4</InlineCode>],
 
       [<InlineCode>margin-bottom</InlineCode>, "", ""],
       [".mb-xs", <InlineCode>var(--responsive-space-xs)</InlineCode>, <InlineCode>80 / 64 / 40</InlineCode>],
       [".mb-s", <InlineCode>var(--responsive-space-s)</InlineCode>, <InlineCode>40 / 24 / 16</InlineCode>],
       [".mb-m", <InlineCode>var(--responsive-space-m)</InlineCode>, <InlineCode>24 / 16 / 12</InlineCode>],
       [".mb-l", <InlineCode>var(--responsive-space-l)</InlineCode>, <InlineCode>16 / 12 / 8</InlineCode>],
-      [".mb-xl", <InlineCode>var(--responsive-space-xl)</InlineCode>, <InlineCode>12 / 8 / 4</InlineCode>]
+      [".mb-xl", <InlineCode>var(--responsive-space-xl)</InlineCode>, <InlineCode>12 / 8 / 4</InlineCode>],
     
       [<InlineCode>margin-left</InlineCode>, "", ""],
       [".ml-xs", <InlineCode>var(--responsive-space-xs)</InlineCode>, <InlineCode>80 / 64 / 40</InlineCode>],
@@ -483,35 +483,35 @@ You can set the static and responsive spacing tokens for different padding prope
       [".px-s", <InlineCode>var(--responsive-space-s)</InlineCode>, <InlineCode>40 / 24 / 16</InlineCode>],
       [".px-m", <InlineCode>var(--responsive-space-m)</InlineCode>, <InlineCode>24 / 16 / 12</InlineCode>],
       [".px-l", <InlineCode>var(--responsive-space-l)</InlineCode>, <InlineCode>16 / 12 / 8</InlineCode>],
-      [".px-xl", <InlineCode>var(--responsive-space-xl)</InlineCode>, <InlineCode>12 / 8 / 4</InlineCode>]
+      [".px-xl", <InlineCode>var(--responsive-space-xl)</InlineCode>, <InlineCode>12 / 8 / 4</InlineCode>],
 
       [<><InlineCode>padding-top</InlineCode> + <InlineCode>padding-bottom</InlineCode></>, "", ""],
       [".py-xs", <InlineCode>var(--responsive-space-xs)</InlineCode>, <InlineCode>80 / 64 / 40</InlineCode>],
       [".py-s", <InlineCode>var(--responsive-space-s)</InlineCode>, <InlineCode>40 / 24 / 16</InlineCode>],
       [".py-m", <InlineCode>var(--responsive-space-m)</InlineCode>, <InlineCode>24 / 16 / 12</InlineCode>],
       [".py-l", <InlineCode>var(--responsive-space-l)</InlineCode>, <InlineCode>16 / 12 / 8</InlineCode>],
-      [".py-xl", <InlineCode>var(--responsive-space-xl)</InlineCode>, <InlineCode>12 / 8 / 4</InlineCode>]
+      [".py-xl", <InlineCode>var(--responsive-space-xl)</InlineCode>, <InlineCode>12 / 8 / 4</InlineCode>],
 
       [<InlineCode>padding-top</InlineCode>, "", ""],
       [".pt-xs", <InlineCode>var(--responsive-space-xs)</InlineCode>, <InlineCode>80 / 64 / 40</InlineCode>],
       [".pt-s", <InlineCode>var(--responsive-space-s)</InlineCode>, <InlineCode>40 / 24 / 16</InlineCode>],
       [".pt-m", <InlineCode>var(--responsive-space-m)</InlineCode>, <InlineCode>24 / 16 / 12</InlineCode>],
       [".pt-l", <InlineCode>var(--responsive-space-l)</InlineCode>, <InlineCode>16 / 12 / 8</InlineCode>],
-      [".pt-xl", <InlineCode>var(--responsive-space-xl)</InlineCode>, <InlineCode>12 / 8 / 4</InlineCode>]
+      [".pt-xl", <InlineCode>var(--responsive-space-xl)</InlineCode>, <InlineCode>12 / 8 / 4</InlineCode>],
 
       [<InlineCode>padding-right</InlineCode>, "", ""],
       [".pr-xs", <InlineCode>var(--responsive-space-xs)</InlineCode>, <InlineCode>80 / 64 / 40</InlineCode>],
       [".pr-s", <InlineCode>var(--responsive-space-s)</InlineCode>, <InlineCode>40 / 24 / 16</InlineCode>],
       [".pr-m", <InlineCode>var(--responsive-space-m)</InlineCode>, <InlineCode>24 / 16 / 12</InlineCode>],
       [".pr-l", <InlineCode>var(--responsive-space-l)</InlineCode>, <InlineCode>16 / 12 / 8</InlineCode>],
-      [".pr-xl", <InlineCode>var(--responsive-space-xl)</InlineCode>, <InlineCode>12 / 8 / 4</InlineCode>]
+      [".pr-xl", <InlineCode>var(--responsive-space-xl)</InlineCode>, <InlineCode>12 / 8 / 4</InlineCode>],
 
       [<InlineCode>padding-bottom</InlineCode>, "", ""],
       [".pb-xs", <InlineCode>var(--responsive-space-xs)</InlineCode>, <InlineCode>80 / 64 / 40</InlineCode>],
       [".pb-s", <InlineCode>var(--responsive-space-s)</InlineCode>, <InlineCode>40 / 24 / 16</InlineCode>],
       [".pb-m", <InlineCode>var(--responsive-space-m)</InlineCode>, <InlineCode>24 / 16 / 12</InlineCode>],
       [".pb-l", <InlineCode>var(--responsive-space-l)</InlineCode>, <InlineCode>16 / 12 / 8</InlineCode>],
-      [".pb-xl", <InlineCode>var(--responsive-space-xl)</InlineCode>, <InlineCode>12 / 8 / 4</InlineCode>]
+      [".pb-xl", <InlineCode>var(--responsive-space-xl)</InlineCode>, <InlineCode>12 / 8 / 4</InlineCode>],
     
       [<InlineCode>padding-left</InlineCode>, "", ""],
       [".pl-xs", <InlineCode>var(--responsive-space-xs)</InlineCode>, <InlineCode>80 / 64 / 40</InlineCode>],

--- a/apps/docs/src/content/once-ui/components/avatarGroup.mdx
+++ b/apps/docs/src/content/once-ui/components/avatarGroup.mdx
@@ -277,7 +277,7 @@ AvatarGroup supports all the same avatar types as the Avatar component.
     ["reverse", "boolean", "false"],
     ["limit", "number"],
     ["style"],
-    ["className"]
+    ["className"],
     ["...flex"]
   ]}
 />

--- a/apps/docs/src/content/once-ui/components/iconButton.mdx
+++ b/apps/docs/src/content/once-ui/components/iconButton.mdx
@@ -205,7 +205,7 @@ Use the children prop to add custom content to the IconButton.
     ["tooltip", "string"],
     ["tooltipPosition", ["top", "bottom", "left", "right"], "top"],
     ["href", "string"],
-    ["id", "string"]
+    ["id", "string"],
     ["children"],
     ["className"],
     ["style"],

--- a/apps/docs/src/content/once-ui/components/scroller.mdx
+++ b/apps/docs/src/content/once-ui/components/scroller.mdx
@@ -134,7 +134,7 @@ You can customize the color of the fade effect that appears behind the scroll bu
     ["onItemClick", "(index: number) => void"],
     ["children"],
     ["className"],
-    ["style"]
+    ["style"],
     ["...flex"]
   ]}
 />


### PR DESCRIPTION
## Broken MDX pages

Three reported pages crashed at runtime:

| Page | Error |
| --- | --- |
| `/once-ui/components/scroller` | `can't access property 0, e is undefined` |
| `/once-ui/basics/spacing` | `can't access property "map", a is undefined` |
| `/once-ui/components/avatarGroup` | `can't access property 0, e is undefined` |

**Cause:** missing commas between adjacent array literals in the MDX. JS parses

```jsx
["style"]
["...flex"]
```

as a member access — `["style"]["...flex"]` — which evaluates to `undefined`, so the array silently ends up one element short with an `undefined` in it. `PropsTable` then reads `propData[0]` and `Table` reads `row.map(...)` on that `undefined`, taking the whole page down.

Fixed in four files (`iconButton` had the same defect but wasn't reported):

- `components/scroller.mdx` — 1
- `components/avatarGroup.mdx` — 1
- `components/iconButton.mdx` — 1
- `basics/spacing.mdx` — 10, spread across the margin/padding tables

Verified in a production build with headless Chromium: all four pages now render with complete tables (scroller 7 prop rows, avatarGroup 7, iconButton 11, spacing 382 rows across 7 tables) and no page errors beyond the ones a known-good control page (`basics/border`) also emits locally.

## OG image

- Content (logo, title, description) is left-aligned inside the existing `8rem` padding, so it sits just inside the vertical grid line at `6rem`.
- The trademark image received `width="200" height="200"` as strings, which satori rejects (`Invalid value "200" for "width"`). It fell back to intrinsic sizing (590×589) and pushed the composition off centre — this is what made the previous centering look broken. Now passed as numbers.
- Description reduced from `3rem`/`3.5rem` to `2.5rem`/`3rem`.
- Removed `text-wrap: balance` (unsupported by satori), the `-2rem` margin that was cancelling out the container gap (gap is now `2rem` directly), and an empty leftover wrapper `div`.

Rendered locally against `/api/og/generate` with a real title + description: logo top-left, title and description left-aligned on the same axis, description visibly smaller than before.