### PR TITLE
1.8.3: repair dead subpath exports, DropdownWrapper fillWidth fixes, resync AI harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ Classified **patch** per [RELEASING.md](RELEASING.md): restores documented behav
 - `apps/docs/public/ai/` claimed to be "synced from @once-ui-system/core on build"
   but no sync step existed, so `docs.once-ui.com/ai/*` could serve stale or missing
   artifacts. A `sync-ai` script now runs before every docs dev/build.
+- `DropdownWrapper` with `fillWidth`: the size middleware widened only the invisible
+  floating container while the visible panel (`Dropdown`) stayed content-sized —
+  on `-end` placements the panel rendered detached at the container's left edge,
+  reading as broken positioning. The panel now fills the container.
+- `DropdownWrapper` with `fillWidth`: removed the hidden 200px width floor
+  (`Math.max(triggerWidth, 200)`). `fillWidth` now means exactly the trigger's
+  width; small triggers no longer get a dropdown overhanging past their edge.
+  Same class of fix as 1.8.2's removal of the 320px content-dropdown floor.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,40 @@ item (see `ROADMAP.md`, Week 4).
 
 ## [Unreleased]
 
+## [1.8.3] — 2026-08-26
+
+Classified **patch** per [RELEASING.md](RELEASING.md): restores documented behavior
+(broken subpath resolution) and AI-harness validity, with no API surface changes.
+
+### Fixed
+
+- The `./icons`, `./types`, and `./interfaces` subpath exports pointed at
+  `dist/<name>/index.js` while the build emits `dist/<name>.js`, leaving all three
+  unresolvable for every consumer (bundlers included) in the published 1.8.0–1.8.2.
+  The exports map now points at the emitted files, and a new
+  `package-exports.test.ts` fails on any exports path the build does not produce.
+- The AI harness shipped in 1.8.2 was still stamped 1.8.1 (`ai/manifest.json`,
+  `ai/catalog.json`, generated 2026-07-30). Artifacts are regenerated at 1.8.3, and a
+  new `ai-manifest-sync.test.ts` enforces the AI-consumer rule from RELEASING.md —
+  harness version must match package version — so this drift class now fails tests.
+- `apps/docs/public/ai/` claimed to be "synced from @once-ui-system/core on build"
+  but no sync step existed, so `docs.once-ui.com/ai/*` could serve stale or missing
+  artifacts. A `sync-ai` script now runs before every docs dev/build.
+
+### Changed
+
+- Backfilled changelog for 1.8.2 (below), which was published without an entry.
+
+## [1.8.2] — 2026-08-02
+
+Classified **patch**: single bug fix, no API surface changes. Published without a
+changelog entry; backfilled in 1.8.3.
+
+### Fixed
+
+- Removed the forced 320px default min-width on content-sized dropdowns
+  (`DropdownWrapper`), restoring content-driven sizing.
+
 ## [1.8.1] — 2026-07-30
 
 Classified **patch** per [RELEASING.md](RELEASING.md): bug fixes restoring documented

--- a/apps/dev/src/app/(main)/dropdown-check/page.tsx
+++ b/apps/dev/src/app/(main)/dropdown-check/page.tsx
@@ -3,12 +3,20 @@
 import { Button, Column, DropdownWrapper, Option, Row, Text } from "@once-ui-system/core";
 
 /**
- * Repro page for the DropdownWrapper regressions reported against 1.8.x:
- * 1. fillWidth dropdown not matching trigger width (org-switcher case)
- * 2. placement detaching from the trigger inside a scrollable panel
- *    (Adjustable "Collection layouts" case: fillWidth + bottom-end)
+ * DropdownWrapper check page — permanent regression fixture.
+ *
+ * Anchors the three sizing/placement cases that regressed across 1.8.x
+ * (320px content floor, 200px fillWidth floor, panel not filling the
+ * floating container). Intended target for the planned Playwright
+ * visual-regression suite (see rfcs/2026-08-once-ui-2-architecture.md §5.6).
+ *
+ * Expected behavior:
+ * 1. fillWidth: the visible panel exactly matches the trigger width.
+ * 2. fillWidth + bottom-end in a scrollable panel: panel sits flush under
+ *    the trigger, no overhang, tracks scroll while open.
+ * 3. No fillWidth: panel stays content-sized.
  */
-export default function DropdownRepro() {
+export default function DropdownCheck() {
   return (
     <Row fillWidth gap="24" padding="24" data-testid="root">
       {/* Case 1: org-switcher style — wide fillWidth trigger */}

--- a/apps/dev/src/app/(main)/dropdown-repro/page.tsx
+++ b/apps/dev/src/app/(main)/dropdown-repro/page.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { Button, Column, DropdownWrapper, Option, Row, Text } from "@once-ui-system/core";
+
+/**
+ * Repro page for the DropdownWrapper regressions reported against 1.8.x:
+ * 1. fillWidth dropdown not matching trigger width (org-switcher case)
+ * 2. placement detaching from the trigger inside a scrollable panel
+ *    (Adjustable "Collection layouts" case: fillWidth + bottom-end)
+ */
+export default function DropdownRepro() {
+  return (
+    <Row fillWidth gap="24" padding="24" data-testid="root">
+      {/* Case 1: org-switcher style — wide fillWidth trigger */}
+      <Column width={30} gap="12" data-testid="case-fill">
+        <Text variant="label-strong-s">Case 1: fillWidth (org switcher)</Text>
+        <DropdownWrapper
+          fillWidth
+          trigger={
+            <Button fillWidth variant="secondary" suffixIcon="chevronDown" data-testid="trigger-fill">
+              Dopler
+            </Button>
+          }
+          dropdown={
+            <Column fillWidth padding="4" gap="2">
+              <Option value="quasar" label="Quasar" />
+              <Option value="dopler" label="Dopler" selected />
+              <Option value="jx" label="JExcellence2" />
+            </Column>
+          }
+        />
+      </Column>
+
+      {/* Case 2: Adjustable style — rows in a scrollable panel, bottom-end */}
+      <Column
+        width={32}
+        height={24}
+        overflowY="auto"
+        border="neutral-alpha-medium"
+        radius="l"
+        padding="12"
+        gap="8"
+        data-testid="panel"
+      >
+        <Text variant="label-strong-s">Case 2: scrollable panel (Adjustable)</Text>
+        {Array.from({ length: 10 }).map((_, i) => (
+          <Row
+            key={i}
+            fillWidth
+            padding="8"
+            gap="12"
+            vertical="center"
+            horizontal="between"
+            radius="l"
+            border="neutral-alpha-weak"
+          >
+            <Column gap="2" paddingLeft="8">
+              <Text variant="label-default-s">Row {i + 1}</Text>
+              <Text variant="label-default-xs" onBackground="neutral-weak">
+                path-{i + 1}
+              </Text>
+            </Column>
+            <Row horizontal="end" gap="8">
+              <DropdownWrapper
+                fillWidth
+                placement="bottom-end"
+                trigger={
+                  <Button
+                    size="s"
+                    variant="secondary"
+                    suffixIcon="chevronDown"
+                    fillWidth
+                    data-testid={`trigger-row-${i + 1}`}
+                  >
+                    Default
+                  </Button>
+                }
+                dropdown={
+                  <Column fillWidth padding="4" gap="2">
+                    <Option value="default" label="Default" selected />
+                    <Option value="blog" label="Blog" />
+                  </Column>
+                }
+              />
+            </Row>
+          </Row>
+        ))}
+      </Column>
+
+      {/* Case 3: content-sized (no fillWidth) — must stay content width */}
+      <Column gap="12" data-testid="case-content">
+        <Text variant="label-strong-s">Case 3: content-sized</Text>
+        <DropdownWrapper
+          trigger={
+            <Button size="s" variant="secondary" suffixIcon="chevronDown" data-testid="trigger-content">
+              Menu
+            </Button>
+          }
+          dropdown={
+            <Column padding="4" gap="2">
+              <Option value="a" label="Settings" />
+              <Option value="b" label="Log out" />
+            </Column>
+          }
+        />
+      </Column>
+    </Row>
+  );
+}

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "predev": "node scripts/sync-ai.mjs",
     "dev": "next dev",
+    "prebuild": "node scripts/sync-ai.mjs",
     "build": "next build",
     "start": "next start",
     "lint": "biome check .",

--- a/apps/docs/scripts/sync-ai.mjs
+++ b/apps/docs/scripts/sync-ai.mjs
@@ -1,0 +1,22 @@
+/**
+ * Syncs the AI harness from @once-ui-system/core into public/ai so the docs
+ * host serves the same artifacts the npm package ships. public/ai is
+ * gitignored; this script is the sync step the ignore file promises. Runs
+ * before dev and build (see package.json predev/prebuild).
+ */
+import { cpSync, existsSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = join(here, "..", "..", "..", "packages", "core", "ai");
+const target = join(here, "..", "public", "ai");
+
+if (!existsSync(source)) {
+  console.error(`sync-ai: source not found: ${source}`);
+  process.exit(1);
+}
+
+rmSync(target, { recursive: true, force: true });
+cpSync(source, target, { recursive: true });
+console.log(`sync-ai: copied packages/core/ai -> public/ai`);

--- a/packages/core/ai/catalog.json
+++ b/packages/core/ai/catalog.json
@@ -1,6 +1,6 @@
 {
  "version": "1.8.3",
- "generated": "2026-08-26",
+ "generated": "2026-08-27",
  "components": {
   "Accordion": {
    "group": "components",

--- a/packages/core/ai/catalog.json
+++ b/packages/core/ai/catalog.json
@@ -1,6 +1,6 @@
 {
- "version": "1.8.1",
- "generated": "2026-07-30",
+ "version": "1.8.3",
+ "generated": "2026-08-26",
  "components": {
   "Accordion": {
    "group": "components",

--- a/packages/core/ai/components/Fade.json
+++ b/packages/core/ai/components/Fade.json
@@ -17,7 +17,7 @@
   "to": "\"bottom\" | \"top\" | \"left\" | \"right\" = bottom",
   "base": "BaseColor = page",
   "blur": "number = 0.5",
-  "pattern": "{ display?: boolean; size?: SpacingToken; } = {\r\n        display: false,\r\n        size: \"4\",\r\n      }",
+  "pattern": "{ display?: boolean; size?: SpacingToken; } = {\n        display: false,\n        size: \"4\",\n      }",
   "style": "React.CSSProperties",
   "children": "ReactNode"
  },

--- a/packages/core/ai/components/RadialGauge.json
+++ b/packages/core/ai/components/RadialGauge.json
@@ -18,7 +18,7 @@
   "line": "{ count?: number; width?: number; length?: number; }",
   "unit": "React.ReactNode",
   "value": "number = 7",
-  "angle": "{ start: number; sweep: number; } = {\r\n    start: 0,\r\n    sweep: 360,\r\n  }",
+  "angle": "{ start: number; sweep: number; } = {\n    start: 0,\n    sweep: 360,\n  }",
   "direction": "'cw' | 'ccw' = cw",
   "edgePad": "number = 0",
   "children": "React.ReactNode",

--- a/packages/core/ai/manifest.json
+++ b/packages/core/ai/manifest.json
@@ -1,6 +1,6 @@
 {
  "version": "1.8.3",
- "generated": "2026-08-26",
+ "generated": "2026-08-27",
  "files": {
   "spec": "spec.json",
   "catalog": "catalog.json",

--- a/packages/core/ai/manifest.json
+++ b/packages/core/ai/manifest.json
@@ -1,6 +1,6 @@
 {
- "version": "1.8.1",
- "generated": "2026-07-30",
+ "version": "1.8.3",
+ "generated": "2026-08-26",
  "files": {
   "spec": "spec.json",
   "catalog": "catalog.json",

--- a/packages/core/ai/spec.json
+++ b/packages/core/ai/spec.json
@@ -1,7 +1,7 @@
 {
  "name": "@once-ui-system/core",
- "version": "1.8.1",
- "generated": "2026-07-30",
+ "version": "1.8.3",
+ "generated": "2026-08-26",
  "format": "props are 'type', 'type = default', or '!type' (required). Components with 'mixins' also accept all props of those mixins. 'extends' means all props of that component are accepted.",
  "tokens": {
   "StaticSpacingToken": "\"0\" | \"1\" | \"2\" | \"4\" | \"8\" | \"12\" | \"16\" | \"20\" | \"24\" | \"32\" | \"40\" | \"48\" | \"56\" | \"64\" | \"80\" | \"104\" | \"128\" | \"160\"",
@@ -962,7 +962,7 @@
     "to": "\"bottom\" | \"top\" | \"left\" | \"right\" = bottom",
     "base": "BaseColor = page",
     "blur": "number = 0.5",
-    "pattern": "{ display?: boolean; size?: SpacingToken; } = {\r\n        display: false,\r\n        size: \"4\",\r\n      }",
+    "pattern": "{ display?: boolean; size?: SpacingToken; } = {\n        display: false,\n        size: \"4\",\n      }",
     "style": "React.CSSProperties",
     "children": "ReactNode"
    }
@@ -2557,7 +2557,7 @@
     "line": "{ count?: number; width?: number; length?: number; }",
     "unit": "React.ReactNode",
     "value": "number = 7",
-    "angle": "{ start: number; sweep: number; } = {\r\n    start: 0,\r\n    sweep: 360,\r\n  }",
+    "angle": "{ start: number; sweep: number; } = {\n    start: 0,\n    sweep: 360,\n  }",
     "direction": "'cw' | 'ccw' = cw",
     "edgePad": "number = 0",
     "children": "React.ReactNode",

--- a/packages/core/ai/spec.json
+++ b/packages/core/ai/spec.json
@@ -1,7 +1,7 @@
 {
  "name": "@once-ui-system/core",
  "version": "1.8.3",
- "generated": "2026-08-26",
+ "generated": "2026-08-27",
  "format": "props are 'type', 'type = default', or '!type' (required). Components with 'mixins' also accept all props of those mixins. 'extends' means all props of that component are accepted.",
  "tokens": {
   "StaticSpacingToken": "\"0\" | \"1\" | \"2\" | \"4\" | \"8\" | \"12\" | \"16\" | \"20\" | \"24\" | \"32\" | \"40\" | \"48\" | \"56\" | \"64\" | \"80\" | \"104\" | \"128\" | \"160\"",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@once-ui-system/core",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Once UI for Next.js NPM package",
   "keywords": [
     "once-ui",
@@ -68,19 +68,19 @@
       "require": "./dist/modules/index.js"
     },
     "./icons": {
-      "types": "./dist/icons/index.d.ts",
-      "import": "./dist/icons/index.js",
-      "require": "./dist/icons/index.js"
+      "types": "./dist/icons.d.ts",
+      "import": "./dist/icons.js",
+      "require": "./dist/icons.js"
     },
     "./types": {
-      "types": "./dist/types/index.d.ts",
-      "import": "./dist/types/index.js",
-      "require": "./dist/types/index.js"
+      "types": "./dist/types.d.ts",
+      "import": "./dist/types.js",
+      "require": "./dist/types.js"
     },
     "./interfaces": {
-      "types": "./dist/interfaces/index.d.ts",
-      "import": "./dist/interfaces/index.js",
-      "require": "./dist/interfaces/index.js"
+      "types": "./dist/interfaces.d.ts",
+      "import": "./dist/interfaces.js",
+      "require": "./dist/interfaces.js"
     },
     "./css/styles.css": "./dist/css/styles.css",
     "./css/tokens.css": "./dist/css/tokens.css",

--- a/packages/core/src/__tests__/ai-manifest-sync.test.ts
+++ b/packages/core/src/__tests__/ai-manifest-sync.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import manifest from "../../ai/manifest.json";
+import catalog from "../../ai/catalog.json";
+import pkg from "../../package.json";
+
+/**
+ * The AI-consumer rule (RELEASING.md): the published ai/ harness artifacts
+ * must describe the version being released. 1.8.2 shipped with a manifest
+ * still stamped 1.8.1 — this test turns that drift class into a failure.
+ * `pnpm build` regenerates the artifacts (generate-ai-spec runs inside it).
+ */
+describe("ai harness version sync", () => {
+  it("ai/manifest.json version matches package.json", () => {
+    expect(manifest.version).toBe(pkg.version);
+  });
+
+  it("ai/catalog.json version matches package.json", () => {
+    expect(catalog.version).toBe(pkg.version);
+  });
+});

--- a/packages/core/src/__tests__/package-exports.test.ts
+++ b/packages/core/src/__tests__/package-exports.test.ts
@@ -1,0 +1,46 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import pkg from "../../package.json";
+
+/**
+ * Asserts every non-wildcard path in the package.json `exports` map points at
+ * a file that the build actually emits.
+ *
+ * Exists because the `./icons`, `./types` and `./interfaces` subpaths shipped
+ * pointing at `dist/<name>/index.js` while the build emits `dist/<name>.js`,
+ * so all three were unresolvable for every consumer until fixed in 1.8.3.
+ *
+ * Requires `dist/` — locally run `pnpm build` first if this suite errors on a
+ * missing dist.
+ */
+
+const PKG_ROOT = join(__dirname, "..", "..");
+
+const collectExportPaths = (entry: unknown, paths: string[] = []): string[] => {
+  if (typeof entry === "string") {
+    paths.push(entry);
+  } else if (entry && typeof entry === "object") {
+    for (const value of Object.values(entry)) {
+      collectExportPaths(value, paths);
+    }
+  }
+  return paths;
+};
+
+describe("package exports integrity", () => {
+  it("dist output exists (build must run before tests)", () => {
+    expect(existsSync(join(PKG_ROOT, "dist", "index.js"))).toBe(true);
+  });
+
+  it("every non-wildcard exports path resolves to an emitted file", () => {
+    const missing = Object.entries(pkg.exports as Record<string, unknown>).flatMap(
+      ([subpath, entry]) =>
+        collectExportPaths(entry)
+          .filter((target) => !target.includes("*"))
+          .filter((target) => !existsSync(join(PKG_ROOT, target)))
+          .map((target) => `${subpath} -> ${target}`),
+    );
+    expect(missing).toEqual([]);
+  });
+});

--- a/packages/core/src/components/DropdownWrapper.tsx
+++ b/packages/core/src/components/DropdownWrapper.tsx
@@ -158,8 +158,10 @@ const DropdownWrapper = forwardRef<HTMLDivElement, DropdownWrapperProps>(
             const floatingStyle = elements.floating.style;
 
             if (fillWidth && triggerRef.current) {
-              const triggerWidth = triggerRef.current.getBoundingClientRect().width;
-              const w = `${Math.max(triggerWidth, 200)}px`;
+              // fillWidth means exactly the trigger's width — no hidden floor.
+              // A wider floor pushes the panel past the trigger on "-end"
+              // placements, which reads as broken positioning.
+              const w = `${triggerRef.current.getBoundingClientRect().width}px`;
               floatingStyle.width = w;
               floatingStyle.minWidth = minWidth ? `${minWidth}rem` : w;
             } else {
@@ -674,6 +676,10 @@ const DropdownWrapper = forwardRef<HTMLDivElement, DropdownWrapperProps>(
                     }}
                   >
                     <Dropdown
+                      // The size() middleware sets the portal's width; the
+                      // visible panel must fill it or it sits detached at the
+                      // portal's left edge on "-end" placements.
+                      fillWidth
                       minWidth={minWidth}
                       radius="l"
                       padding="0"
@@ -768,6 +774,7 @@ const DropdownWrapper = forwardRef<HTMLDivElement, DropdownWrapperProps>(
                   }}
                 >
                   <Dropdown
+                    fillWidth
                     minWidth={minWidth}
                     radius="l"
                     padding="0"


### PR DESCRIPTION
## Summary

Patch release prep for **1.8.3** — restores documented behavior and AI-harness validity, no API surface changes (patch per RELEASING.md). Publish remains maintainer-only; this PR gets everything ready.

## Fixed

- **Dead subpath exports in the published package.** `./icons`, `./types`, and `./interfaces` point at `dist/<name>/index.js` while the build emits `dist/<name>.js` — verified against the published 1.8.2 tarball, all three subpaths are unresolvable for every consumer (bundlers included) and have been since 1.8.0. The exports map now points at the emitted files. Same fix as `cb3d7b9` on the `v2` branch, hand-applied without that commit's publint/attw additions and RFC edits to keep the patch minimal.
- **DropdownWrapper `fillWidth` — two regressions from the 1.8.x dropdown refactors** (the Aveiro org-switcher / Adjustable-row reports), reproduced and verified with a Playwright probe against a new `apps/dev/dropdown-repro` page:
  - The `size()` middleware widened only the invisible floating container; the visible `Dropdown` panel stayed content-sized, so on `-end` placements the panel hugged the container's left edge and rendered **detached from the trigger** — the anchor math was correct, the visible panel wasn't filling it. The panel now fills the container.
  - The `Math.max(triggerWidth, 200)` floor made small triggers' dropdowns overhang 100px+ past their edge. `fillWidth` now means exactly the trigger's width (explicit `minWidth` still applies) — same disease as the 320px content floor removed in 1.8.2.
  - Measured: fillWidth trigger w=469 → panel 116px before, 469px after. Small trigger w=92, `bottom-end` → container 200px overhanging before, 92px flush after. Scroll tracking and content-sized dropdowns unaffected.
- **Stale AI harness.** 1.8.2 shipped `ai/manifest.json` / `ai/catalog.json` still stamped 1.8.1. Regenerated at 1.8.3 via the existing build step.
- **Docs `public/ai` sync now exists.** `apps/docs/.gitignore` promised a build sync that didn't exist; added `scripts/sync-ai.mjs` wired as `predev`/`prebuild`.

## Guards added (these drift classes now fail tests)

- `package-exports.test.ts` — every non-wildcard `exports` path must resolve to a file the build emits.
- `ai-manifest-sync.test.ts` — enforces the RELEASING.md AI-consumer rule: harness version must equal `package.json`'s.

## Changelog

- Added the `[1.8.3]` entry (including the DropdownWrapper fixes); backfilled the missing `[1.8.2]` entry (dropdown min-width fix, published 2026-08-02 with no changelog).

## Verification

- `pnpm test` in `packages/core`: **96 passed**, typecheck clean.
- `pnpm build` regenerates `ai/` at 1.8.3 and emits the dist layout the fixed exports point at.
- Playwright before/after measurements for all three dropdown cases (fillWidth wide, fillWidth small + `bottom-end` in a scrollable panel, content-sized control).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsN93NU2Vp5axBdT3nLrZA