### PR TITLE
Record AI harness eval baseline (2026-08-26)

### DIFF
--- a/docs/evals/2026-08-26-baseline.md
+++ b/docs/evals/2026-08-26-baseline.md
@@ -1,0 +1,69 @@
+# AI harness eval baseline — 2026-08-26
+
+First recorded run of the fixed eval suite (`packages/core/ai/eval-tasks.md`),
+measuring harness effectiveness at core **1.8.3**.
+
+## Method
+
+- All 12 suite tasks, two conditions, same model (Claude, this session's):
+  - **without** — written from model memory only; no file reads permitted.
+  - **with** — agent required to read `ai/rules.compact.md` + `ai/catalog.json`
+    (+ task bundles and per-component slices as needed) before writing.
+- Generation batched 3 tasks per agent (4 agents per condition) — mild
+  within-agent context sharing, identical across conditions.
+- Mechanical scoring: `scripts/validate-ai-code.js` per file, plus strict
+  `tsc --noEmit` against the installed `@once-ui-system/core` 1.8.2 dist types.
+- Judgment scoring: single blind-ish rubric pass (1–5 per axis), calibrated
+  against `ai/rules.compact.md` and two gold examples.
+- Raw outputs retained session-side; the suite is fully re-runnable from `packages/core/ai/eval-tasks.md`.
+
+## Headline results
+
+| Metric | without harness | with harness |
+|---|---|---|
+| validate-ai-code issues (total) | **22** across 9/12 files | **3** across 2/12 files |
+| strict tsc: files failing | **11/12** (24 errors) | **0/12** |
+| Proportionality (mean, 1–5) | 3.25 | 5.00 |
+| Component appropriateness | 3.08 | 4.92 |
+| Responsiveness | 2.50 | 4.33 |
+| Restraint | 4.00 | 4.92 |
+| Distinct components used (mean) | 11.5 | 11.25 |
+
+## What the harness actually changes
+
+Not component *quantity* (distinct-import counts are identical) — component
+*correctness and selection*:
+
+1. **Invented responsive APIs are the #1 memory failure.** Memory output
+   consistently emits `tabletColumns` / `mobileColumns` / `mobileDirection`
+   and values like `horizontal="space-between"` — none exist; layouts would
+   silently not adapt. Harness output uses the real breakpoint objects
+   (`m={{ columns: 2 }}`, `s={{ direction: "column" }}`).
+2. **Era drift.** Memory reaches for removed-era APIs (`SmartImage`) and
+   unknown icon names (`upload`, `sparkles`, `shoppingCart`, `arrowLeft`,
+   `logout`); confirms "memory from older sessions is not a source."
+3. **Purpose-built vs hand-rolled.** Harness picks `Timeline`, `LogoCloud`,
+   `HoverCard`/`UserMenu`, `EmojiPickerDropdown`, `MediaUpload`,
+   `DateRangeInput`, `StatusIndicator`, `CelebrationFx`, and `Table`'s
+   built-in `paginated`/`sortable`/`emptyState`; memory hand-rolls timeline
+   dots, manual pagination with string sort arrows, an emoji grid.
+4. **Design-system rhythm.** Harness follows the gold rhythm (numeric tokens,
+   104 section gaps, the surface recipe); memory mixes t-shirt spacing and
+   off-recipe surfaces.
+5. **Restraint parity is illusory** — memory scores 4.0 by omitting effects
+   entirely; the harness adds budgeted motion and still stays inside the
+   ambient-layer budget. Memory also produced a latent runtime bug
+   (`useToast` with no `ToastProvider`).
+
+## Residual harness misses (pitfall-log candidates)
+
+- `Fade` wrapped scroll content instead of being used as an absolute edge
+  strip (task04) — candidate rules.md reinforcement.
+- One stray non-icon string reached an icon-typed prop (task10).
+
+## Re-run protocol
+
+Re-run this suite with the same 12 tasks, same two conditions, and the same
+scoring stack after every harness change (rules/catalog/slices/gotchas edits),
+and publish deltas with 2.0. The mechanical half (validate + tsc) is fully
+scriptable; keep the judgment pass calibrated against the same gold examples.


### PR DESCRIPTION
Docs-only follow-up to #127, held out of that PR to keep the 1.8.3 patch clean.

Adds `docs/evals/2026-08-26-baseline.md` — the first recorded run of the fixed eval suite (`packages/core/ai/eval-tasks.md`): all 12 tasks, generated with and without the AI harness, scored mechanically (`validate-ai-code` + strict `tsc` against the installed dist types) and on the suite's four judgment axes.

**Headline:** without the harness — 22 validator issues across 9/12 files and 11/12 files failing strict typecheck; with the harness — 3 issues across 2/12 files and 0 typecheck failures. Judgment means rise from ~3.0 to ~4.8 with identical distinct-component counts: the harness changes component *correctness and selection*, not quantity. The report includes the failure taxonomy (invented responsive props like `tabletColumns`/`mobileDirection`, era drift like `SmartImage`, hand-rolled UI where purpose-built components exist), the residual harness misses as pitfall-log candidates, and the re-run protocol for gating future harness changes.

These are the "before" numbers the 2.0 quality claims measure against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsN93NU2Vp5axBdT3nLrZA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UsN93NU2Vp5axBdT3nLrZA)_