### PR TITLE
release: 1.8.4 — ThemeInit fix only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,42 @@ item (see `ROADMAP.md`, Week 4).
 
 ## [Unreleased]
 
+## [1.8.4] — 2026-08-28
+
+Classified **patch** per [RELEASING.md](RELEASING.md): a single bug fix, no
+API change of any kind. Cut from the tree that produced the published 1.8.3
+rather than from `main`, so it carries none of the 2.0 architecture work in
+flight on the release branch — the fix reaches `^1.8.x` consumers on their
+next install, with nothing to migrate.
+
+### Fixed
+
+- `ThemeInit`: the inline theme-bootstrap script threw
+  `ReferenceError: ThemeInit is not defined` on every page load in every consumer
+  app. A `ThemeInit.displayName = "ThemeInit"` assignment had been injected *inside*
+  the script's template literal (and the arrow function above it de-indented),
+  so the emitted `<script>` referenced a module-scope binding that does not exist
+  in the browser. The throw was swallowed by the script's own `try/catch`, which
+  then hard-set `data-theme="dark"`.
+
+  Effect: the script's whole point — applying the saved theme and style overrides
+  *before* first paint — never ran. A visitor with `data-theme=light` saved got a
+  dark flash on every navigation, and saved `data-brand`/`data-neutral` overrides
+  flashed the config defaults until React hydrated and the provider corrected them.
+  Present in source, so every published version carrying this file is affected.
+
+  The `catch` fallback no longer hardcodes `dark` either: it resolves
+  `prefers-color-scheme`, since forcing dark on a light-mode visitor is a worse
+  failure than the one it is recovering from.
+
+  A new `theme-init.test.tsx` parses *and executes* the emitted script against
+  jsdom — asserting it references nothing from module scope, throws nothing, and
+  actually applies saved theme and style overrides — so this class of corruption
+  fails tests instead of shipping. Verified end-to-end in a consumer app: with
+  a saved `light` theme and `cyan` brand on a dark-preferring OS, first paint went
+  from `theme=dark, brand=blue` (plus the console error) to `theme=light,
+  brand=cyan` with a clean console.
+
 ## [1.8.3] — 2026-08-26
 
 Classified **patch** per [RELEASING.md](RELEASING.md): restores documented behavior

--- a/packages/core/ai/catalog.json
+++ b/packages/core/ai/catalog.json
@@ -1,6 +1,6 @@
 {
- "version": "1.8.3",
- "generated": "2026-08-27",
+ "version": "1.8.4",
+ "generated": "2026-08-28",
  "components": {
   "Accordion": {
    "group": "components",

--- a/packages/core/ai/manifest.json
+++ b/packages/core/ai/manifest.json
@@ -1,6 +1,6 @@
 {
- "version": "1.8.3",
- "generated": "2026-08-27",
+ "version": "1.8.4",
+ "generated": "2026-08-28",
  "files": {
   "spec": "spec.json",
   "catalog": "catalog.json",

--- a/packages/core/ai/spec.json
+++ b/packages/core/ai/spec.json
@@ -1,7 +1,7 @@
 {
  "name": "@once-ui-system/core",
- "version": "1.8.3",
- "generated": "2026-08-27",
+ "version": "1.8.4",
+ "generated": "2026-08-28",
  "format": "props are 'type', 'type = default', or '!type' (required). Components with 'mixins' also accept all props of those mixins. 'extends' means all props of that component are accepted.",
  "tokens": {
   "StaticSpacingToken": "\"0\" | \"1\" | \"2\" | \"4\" | \"8\" | \"12\" | \"16\" | \"20\" | \"24\" | \"32\" | \"40\" | \"48\" | \"56\" | \"64\" | \"80\" | \"104\" | \"128\" | \"160\"",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@once-ui-system/core",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "Once UI for Next.js NPM package",
   "keywords": [
     "once-ui",

--- a/packages/core/src/__tests__/theme-init.test.tsx
+++ b/packages/core/src/__tests__/theme-init.test.tsx
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ThemeInit } from "../components/ThemeInit";
+
+/**
+ * ThemeInit emits a blocking inline <script> as a template literal. Nothing in
+ * the normal build pipeline type-checks or parses that string, so a bad edit
+ * inside it ships to npm and only shows up as a console error in consumer apps
+ * (this happened: a `displayName` assignment was injected into the literal,
+ * throwing ReferenceError on every page load and pinning the theme).
+ *
+ * These tests parse and run the emitted script, so the failure mode is a red
+ * test rather than a runtime error in someone else's app.
+ */
+
+const config = {
+  theme: "system",
+  brand: "blue",
+  accent: "indigo",
+  neutral: "gray",
+  solid: "contrast",
+  "solid-style": "flat",
+  border: "playful",
+  surface: "translucent",
+  transition: "all",
+  scaling: "100",
+  "viz-style": "categorical",
+};
+
+function emittedScript(): string {
+  // ThemeInit is a plain function component returning a <script> element.
+  const element = ThemeInit({ config }) as React.ReactElement<{
+    dangerouslySetInnerHTML: { __html: string };
+  }>;
+  return element.props.dangerouslySetInnerHTML.__html;
+}
+
+/** Run the emitted script against the jsdom document. */
+function runScript(): void {
+  // biome-ignore lint/security/noGlobalEval: executing the emitted script is the point of the test
+  new Function(emittedScript())();
+}
+
+describe("ThemeInit emitted script", () => {
+  beforeEach(() => {
+    document.documentElement.removeAttribute("data-theme");
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("is syntactically valid JavaScript", () => {
+    expect(() => new Function(emittedScript())).not.toThrow();
+  });
+
+  it("references nothing from the module scope", () => {
+    // The script runs in the browser before any bundle loads, so any identifier
+    // from this module (ThemeInit, React, imports) would be a ReferenceError.
+    expect(emittedScript()).not.toContain("displayName");
+    expect(emittedScript()).not.toContain("ThemeInit");
+  });
+
+  it("runs without throwing and reports no error", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(runScript).not.toThrow();
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it("applies every config key as a data attribute", () => {
+    runScript();
+    for (const [key, value] of Object.entries(config)) {
+      if (key === "theme") continue; // theme is resolved, not copied verbatim
+      expect(document.documentElement.getAttribute(`data-${key}`)).toBe(value);
+    }
+  });
+
+  it("resolves theme 'system' from the media query", () => {
+    vi.spyOn(window, "matchMedia").mockImplementation(
+      (query: string) => ({ matches: query.includes("dark") }) as MediaQueryList,
+    );
+    runScript();
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+  });
+
+  it("prefers a saved theme over the config default", () => {
+    localStorage.setItem("data-theme", "light");
+    vi.spyOn(window, "matchMedia").mockImplementation(
+      (query: string) => ({ matches: query.includes("dark") }) as MediaQueryList,
+    );
+    runScript();
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+  });
+
+  it("applies saved style overrides on top of the config", () => {
+    localStorage.setItem("data-brand", "cyan");
+    runScript();
+    expect(document.documentElement.getAttribute("data-brand")).toBe("cyan");
+  });
+
+  it("falls back to the system preference when it throws", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    // Force the try block to fail after the media-query stub is in place.
+    const storage = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("localStorage unavailable");
+    });
+    vi.spyOn(window, "matchMedia").mockImplementation(
+      () => ({ matches: false }) as MediaQueryList,
+    );
+
+    expect(runScript).not.toThrow();
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+    storage.mockRestore();
+  });
+});

--- a/packages/core/src/components/ThemeInit.tsx
+++ b/packages/core/src/components/ThemeInit.tsx
@@ -40,9 +40,7 @@ export const ThemeInit: React.FC<ThemeInitProps> = ({ config }) => {
                   return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
                 }
                 return themeValue;
-};
-
-ThemeInit.displayName = "ThemeInit";
+              };
 
               // Priority:
               // 1. localStorage
@@ -62,7 +60,11 @@ ThemeInit.displayName = "ThemeInit";
 
             } catch (e) {
               console.error('Failed to initialize theme:', e);
-              document.documentElement.setAttribute('data-theme', 'dark');
+              // Fall back to the system preference, not a hardcoded theme: forcing
+              // dark on a light-mode visitor is a worse failure than doing nothing.
+              var prefersDark = window.matchMedia
+                && window.matchMedia('(prefers-color-scheme: dark)').matches;
+              document.documentElement.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
             }
           })();
         `,


### PR DESCRIPTION
Ships the ThemeInit repair on its own, ahead of the 2.0 architecture work, so it reaches `^1.8.x` consumers on their next install with nothing to migrate. The release branch keeps foundations, the framework adapter and the Next-optional work for 2.0.

Cut from 94dde18, the tree that produced the published 1.8.3 — not from `main`, which already carries the 2.0 phases.

Picking the base needed care. The obvious candidate was d9933a1, the commit that sets version 1.8.3, but the published tarball proves it is not what shipped: 1.8.3's dist contains the DropdownWrapper fillWidth fix (8d65f01) and d9933a1 does not. Building from d9933a1 would have quietly reverted a fix that is already live. The reconcile merges on main make commit order misleading, so the base was chosen by comparing against the published artifact rather than by reading the log.

Verified against the published 1.8.3 tarball, comparing every file in dist with line endings normalised (1.8.3 was built on a CRLF machine):

- components/ThemeInit.js is the ONLY .js file that differs
- exports map, dependencies and peerDependencies are byte-identical
- 7 dependencies, no foundations
- 104 tests pass, including the 8 new theme-init tests that parse and execute the emitted script

The .d.ts files differ only in declaration emit — `import("react/jsx-runtime") .JSX.Element` vs `import("react").JSX.Element` — an artifact of this machine's TypeScript/@types/react versions, not a type change. Publishing from a maintainer checkout regenerates them anyway.