### PR TITLE
fix: restore core's version to 2.0.0-alpha.0 on main

### DIFF
--- a/packages/core/ai/catalog.json
+++ b/packages/core/ai/catalog.json
@@ -1,6 +1,6 @@
 {
- "version": "1.9.0",
- "generated": "2026-08-27",
+ "version": "2.0.0-alpha.0",
+ "generated": "2026-08-28",
  "components": {
   "Accordion": {
    "group": "components",

--- a/packages/core/ai/manifest.json
+++ b/packages/core/ai/manifest.json
@@ -1,6 +1,6 @@
 {
- "version": "1.9.0",
- "generated": "2026-08-27",
+ "version": "2.0.0-alpha.0",
+ "generated": "2026-08-28",
  "files": {
   "spec": "spec.json",
   "catalog": "catalog.json",

--- a/packages/core/ai/spec.json
+++ b/packages/core/ai/spec.json
@@ -1,7 +1,7 @@
 {
  "name": "@once-ui-system/core",
- "version": "1.9.0",
- "generated": "2026-08-27",
+ "version": "2.0.0-alpha.0",
+ "generated": "2026-08-28",
  "format": "props are 'type', 'type = default', or '!type' (required). Components with 'mixins' also accept all props of those mixins. 'extends' means all props of that component are accepted.",
  "tokens": {
   "StaticSpacingToken": "\"0\" | \"1\" | \"2\" | \"4\" | \"8\" | \"12\" | \"16\" | \"20\" | \"24\" | \"32\" | \"40\" | \"48\" | \"56\" | \"64\" | \"80\" | \"104\" | \"128\" | \"160\"",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@once-ui-system/core",
-  "version": "1.9.0",
+  "version": "2.0.0-alpha.0",
   "description": "Once UI for Next.js NPM package",
   "keywords": [
     "once-ui",


### PR DESCRIPTION
## What

`packages/core/package.json` goes from `1.9.0` back to **`2.0.0-alpha.0`**, and the three `ai/*` artifacts restamp to match. No source changes — 4 files, 7 lines.

## Why

The merge in `94e87a3` resolved a conflict on `packages/core/package.json` by taking `1.9.0`, while letting `packages/foundations` come through at `2.0.0-alpha.0` from the same merge. The two halves of one release disagree:

```
core         1.9.0
foundations  2.0.0-alpha.0
```

`2.0.0-alpha.0` is what `d6c0485` ("extract `@once-ui-system/foundations`", 2.0 Phase 1) set deliberately, and what foundations still carries. No commit on main ever introduced `1.9.0` through a normal diff — `git log -S '"version": "1.9.0"'` finds none — because it exists only as a merge resolution. Walking main's first-parent history shows the flip landing exactly at that merge:

| commit | core | foundations |
| --- | --- | --- |
| `94e87a3` (the merge) | **1.9.0** | 2.0.0-alpha.0 |
| `866f947` | 1.8.3 | — |
| `1c9c446` | 1.8.3 | — |

## Why it isn't cosmetic

**Nothing will ever publish as 1.9.0.** The `ThemeInit` fix ships as **1.8.4** from its own branch, cut from the tree that produced the published 1.8.3; everything else on this line becomes **2.0**. 1.9.0 was a working number bumped ahead of any release decision, and it is now skipped entirely.

Leaving main at `1.9.0` means `pnpm pack` from main produces a `1.9.0` tarball that must never reach npm. Publishing is done by hand from a local checkout, so being on the wrong branch is a realistic failure mode rather than a theoretical one.

`ai-manifest-sync.test.ts` enforces that the harness version equals the package version, so once both sides agree they cannot drift apart again.

## Verification

- `pnpm test` — **124 core + 3 foundations** passed
- `pnpm build` — clean
- `ai/manifest.json`, `ai/spec.json`, `ai/catalog.json` restamped to `2.0.0-alpha.0`

## Related

The same correction is already on the release branch (`bbe7a29`), together with dropping the dated `## [1.9.0]` changelog heading and moving the `ThemeInit` entry to where it belongs. This PR brings main in line so the two don't conflict again on the next merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UsN93NU2Vp5axBdT3nLrZA)_