### PR TITLE
docs: add the 1.8.4 changelog entry

### DIFF
--- a/apps/docs/src/resources/changelog.jsx
+++ b/apps/docs/src/resources/changelog.jsx
@@ -2,6 +2,21 @@ import { SmartLink, InlineCode } from "@once-ui-system/core";
 
 const changelog = [
   {
+    date: "2026-08-28",
+    title: "Once UI 1.8.4",
+    sections: [
+      {
+        title: "Fixes",
+        bullets: [
+          <><SmartLink unstyled href="/once-ui/contexts/themeProvider">ThemeInit</SmartLink>: the inline theme-bootstrap script threw <InlineCode>ReferenceError: ThemeInit is not defined</InlineCode> on every page load, in every app. A <InlineCode>displayName</InlineCode> assignment had been injected inside the script&apos;s template literal, so the browser evaluated a binding that does not exist there. The script&apos;s own <InlineCode>try/catch</InlineCode> swallowed the throw and hard-set <InlineCode>data-theme=&quot;dark&quot;</InlineCode>, which is why it survived to npm with only a console error to show for it</>,
+          <>What it actually broke: the script exists to apply your saved theme and style overrides <i>before</i> first paint, and none of that ran. A visitor with <InlineCode>light</InlineCode> saved got a dark flash on every navigation, and saved <InlineCode>data-brand</InlineCode> / <InlineCode>data-neutral</InlineCode> overrides flashed the config defaults until React hydrated</>,
+          <>The <InlineCode>catch</InlineCode> fallback no longer hardcodes dark either — it resolves <InlineCode>prefers-color-scheme</InlineCode>, since forcing dark on a light-mode visitor is a worse failure than the one it is recovering from</>,
+          <>Every published version carrying this file was affected. Upgrading is enough: <InlineCode>^1.8.x</InlineCode> ranges resolve to 1.8.4 on your next install, with nothing to migrate</>,
+        ],
+      },
+    ],
+  },
+  {
     date: "2026-08-26",
     title: "Once UI 1.8.3",
     sections: [


### PR DESCRIPTION
## What

Adds the `1.8.4` entry to `apps/docs/src/resources/changelog.jsx`, the page behind `docs.once-ui.com/changelog`. One file.

RELEASING.md step 5 — 1.8.4 published to npm on 2026-08-28 (`dist-tags.latest = 1.8.4`).

## The entry

Covers the `ThemeInit` repair in the terms a reader cares about: what threw, why the script's own `try/catch` hid it all the way to npm, and what it actually cost — saved theme and `data-brand` / `data-neutral` overrides never applied before first paint, so a visitor with `light` saved got a dark flash on every navigation. Also notes the `catch` fallback no longer hardcodes dark, and that upgrading is the whole migration: `^1.8.x` resolves to 1.8.4 on the next install.

## Link check

`ThemeInit` links to `/once-ui/contexts/themeProvider`, which documents it. My first draft pointed at `/once-ui/basics/themes`, which **does not exist** — `basics/` has border, color, components, responsive, spacing, structure and typography, and no themes page. Every `href` in the new entry was checked against `apps/docs/src/content` before committing.

Worth flagging since this file already carried a dead link (`/once-ui/components/headingLink`, fixed in the 1.8.1–1.8.3 backfill) — it's hand-written JSX with no link validation, so this is a recurring failure mode.

## Standing issue this doesn't fix

`CHANGELOG.md` calls itself the source of truth *"GitHub release notes and any published changelog pages are generated from it, not the other way around"* — but this page is hand-maintained JSX. That two-source split is how the page fell three releases behind before the recent backfill, and it will reopen. Generating this file from `CHANGELOG.md` would close it; not in scope here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UsN93NU2Vp5axBdT3nLrZA)_